### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
    		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-		<maven.javadoc.plugin.version>3.2.0</maven.javadoc.plugin.version>
+		<maven.javadoc.plugin.version>3.3.0</maven.javadoc.plugin.version>
 		<maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
-		<maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
+		<maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
 		<junit.version>4.13.2</junit.version>
 		<javax.validation-api.version>2.0.1.Final</javax.validation-api.version>
-		<aerospike-client.version>5.0.7</aerospike-client.version>
+		<aerospike-client.version>5.1.2</aerospike-client.version>
 		<commons-lang3.version>3.12.0</commons-lang3.version>
 		<jackson-dataformat-yaml.version>2.12.3</jackson-dataformat-yaml.version>
 	</properties>


### PR DESCRIPTION
maven-javadoc-plugin from 3.2.0 to 3.3.0.
maven-compiler-plugin from 3.8.0 to 3.8.1.
aerospike-client from 5.0.7 to 5.1.2.