### PR TITLE
Fixed recursive Objects

### DIFF
--- a/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
@@ -389,6 +389,10 @@ public class AeroMapper implements IAeroMapper {
     }
 
     private <T> T read(Policy readPolicy, @NotNull Class<T> clazz, @NotNull Key key, @NotNull ClassCacheEntry<T> entry, boolean resolveDependencies) {
+    	Object objectForKey = LoadedObjectResolver.get(key);
+    	if (objectForKey != null) {
+    		return (T)objectForKey;
+    	}
         if (readPolicy == null) {
             readPolicy = entry.getReadPolicy();
         }
@@ -399,11 +403,13 @@ public class AeroMapper implements IAeroMapper {
         } else {
             try {
                 ThreadLocalKeySaver.save(key);
+                LoadedObjectResolver.begin();
                 return mappingConverter.convertToObject(clazz, record, entry, resolveDependencies);
             } catch (ReflectiveOperationException e) {
                 throw new AerospikeException(e);
             }
             finally {
+                LoadedObjectResolver.end();
                 ThreadLocalKeySaver.clear();
             }
         }

--- a/src/main/java/com/aerospike/mapper/tools/ClassCache.java
+++ b/src/main/java/com/aerospike/mapper/tools/ClassCache.java
@@ -53,6 +53,13 @@ public class ClassCache {
 		ClassCacheEntry<T> entry = cacheMap.get(clazz);
 		if (entry == null) {
 			try {
+				// Construct a class cache entry. This must be done in 2 steps, one creating the entry and the other finalizing construction of 
+				// it. This is to cater for classes  which recursively refer to themselves, such as
+				// 	public static class A {
+				//      @AerospikeKey
+				//      public int id;
+				//      public A a;
+				//  }
 				entry = new ClassCacheEntry<>(clazz, mapper, getClassConfig(clazz),
 						determinePolicy(clazz, PolicyType.READ),
 						(WritePolicy) determinePolicy(clazz, PolicyType.WRITE),
@@ -64,6 +71,13 @@ public class ClassCache {
 				return null;
 			}
 			cacheMap.put(clazz, entry);
+			try {
+				entry.construct();
+			}
+			catch (IllegalArgumentException iae) {
+				cacheMap.remove(clazz);
+				return null;
+			}
 		}
 		return entry;
 	}

--- a/src/main/java/com/aerospike/mapper/tools/LoadedObjectResolver.java
+++ b/src/main/java/com/aerospike/mapper/tools/LoadedObjectResolver.java
@@ -1,0 +1,45 @@
+package com.aerospike.mapper.tools;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.aerospike.client.Key;
+
+public class LoadedObjectResolver {
+	
+	private static class LoadedObjectMap {
+		private int referenceCount = 0;
+		private final Map<Key, Object> objectMap = new HashMap<>(); 
+	}
+	
+	private static final ThreadLocal<LoadedObjectMap> threadLocalObjects = ThreadLocal.withInitial(LoadedObjectMap::new);
+	
+	public static void begin() {
+		LoadedObjectMap map = threadLocalObjects.get();
+		map.referenceCount++;
+	}
+
+	public static void end() {
+		LoadedObjectMap map = threadLocalObjects.get();
+		map.referenceCount--;
+		if (map.referenceCount == 0) {
+			map.objectMap.clear();
+		}
+	}
+	
+	public static void setObjectForCurrentKey(Object object) {
+		Key currentKey = ThreadLocalKeySaver.get();
+		LoadedObjectMap map = threadLocalObjects.get();
+		if (currentKey != null) {
+			map.objectMap.put(currentKey, object);
+		}
+	}
+//	public static void add(Object key, Object object) {
+//		threadLocalObjects.get().objectMap.put(key, object);
+//	}
+	
+	public static Object get(Key key) {
+		LoadedObjectMap map = threadLocalObjects.get();
+		return map.objectMap.get(key);
+	}
+}

--- a/src/main/java/com/aerospike/mapper/tools/ThreadLocalKeySaver.java
+++ b/src/main/java/com/aerospike/mapper/tools/ThreadLocalKeySaver.java
@@ -21,6 +21,10 @@ public class ThreadLocalKeySaver {
 	}
 	
 	public static Key get() {
-		return threadLocalKeys.get().getLast();
+		Deque<Key> keys = threadLocalKeys.get();
+		if (keys.isEmpty()) {
+			return null;
+		}
+		return keys.getLast();
 	}
 }

--- a/src/main/java/com/aerospike/mapper/tools/converters/MappingConverter.java
+++ b/src/main/java/com/aerospike/mapper/tools/converters/MappingConverter.java
@@ -179,6 +179,13 @@ public class MappingConverter {
         return entry.getMap(instance, false);
     }
 
+    private Key createKey(ClassCacheEntry<?> entry, DeferredObjectLoader.DeferredObject deferredObject) {
+        if (deferredObject.isDigest()) {
+            return new Key(entry.getNamespace(), (byte[])deferredObject.getKey(), entry.getSetName(), null);
+        } else {
+            return new Key(entry.getNamespace(), entry.getSetName(), Value.get(entry.translateKeyToAerospikeKey(deferredObject.getKey())));
+        }
+    }
     /**
      * If an object refers to other objects (eg A has a list of B via references), then reading the object will populate the
      * ids. If configured to do so, these objects can be loaded via a batch load and populated back into the references which
@@ -210,14 +217,7 @@ public class MappingConverter {
                 Class<?> clazz = deferredObject.getType();
                 ClassCacheEntry<?> entry = MapperUtils.getEntryAndValidateNamespace(clazz, mapper);
 
-                Key aKey;
-
-                if (deferredObject.isDigest()) {
-                    aKey = new Key(entry.getNamespace(), (byte[])deferredObject.getKey(), entry.getSetName(), null);
-                } else {
-                    aKey = new Key(entry.getNamespace(), entry.getSetName(), Value.get(entry.translateKeyToAerospikeKey(deferredObject.getKey())));
-                }
-                
+                Key aKey = createKey(entry, deferredObject);
                 Object result = LoadedObjectResolver.get(aKey);
                 if (result != null) {
                     thisObjectSetter.getSetter().setValue(result);

--- a/src/test/java/com/aerospike/mapper/RecursiveObjectTest.java
+++ b/src/test/java/com/aerospike/mapper/RecursiveObjectTest.java
@@ -23,6 +23,7 @@ public class RecursiveObjectTest extends AeroMapperBaseTest {
 		public A(String name, int age, int id) {
 			super();
 			this.name = name;
+			this.age = age;
 			this.id = id;
 		}
 	}
@@ -64,5 +65,20 @@ public class RecursiveObjectTest extends AeroMapperBaseTest {
 		assertEquals(b.a.age, b2.a.age);
 		assertEquals(b.a.name, b2.a.name);
 		assertEquals(b.a.id, b2.a.id);
+	}
+	
+	@Test
+	public void runTest2() {
+		A a1 = new A("a", 10, 1);
+		a1.a = new A("a2", 11, 11);
+
+		AeroMapper mapper = new AeroMapper.Builder(client).build();
+		mapper.save(a1, a1.a);
+		
+		A a2 = mapper.read(A.class, a1.id);
+		assertEquals(a1.age, a2.age);
+		assertEquals(a1.name, a2.name);
+		assertEquals(a1.id, a2.id);
+		assertEquals(a1.a.id, a2.a.id);
 	}
 }

--- a/src/test/java/com/aerospike/mapper/RecursiveObjectTest.java
+++ b/src/test/java/com/aerospike/mapper/RecursiveObjectTest.java
@@ -1,0 +1,68 @@
+package com.aerospike.mapper;
+
+import org.junit.jupiter.api.Test;
+
+import com.aerospike.mapper.annotations.AerospikeKey;
+import com.aerospike.mapper.annotations.AerospikeRecord;
+import com.aerospike.mapper.tools.AeroMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RecursiveObjectTest extends AeroMapperBaseTest {
+	@AerospikeRecord(namespace = "test", set = "A")
+	public static class A {
+		public String name;
+		public int age;
+		@AerospikeKey
+		public int id;
+//		@AerospikeReference(batchLoad = false)
+		public A a;
+		
+		A() {}
+
+		public A(String name, int age, int id) {
+			super();
+			this.name = name;
+			this.id = id;
+		}
+	}
+	
+	@AerospikeRecord(namespace = "test", set = "B")
+	public static class B {
+		@AerospikeKey
+		public int id ;
+		public A a;
+	}
+	
+	@Test
+	public void runTest() {
+		A a1 = new A("a", 10, 1);
+		a1.a = a1;
+		
+		AeroMapper mapper = new AeroMapper.Builder(client).build();
+		mapper.save(a1);
+		
+		A a2 = mapper.read(A.class, a1.id);
+		assertEquals(a1.age, a2.age);
+		assertEquals(a1.name, a2.name);
+		assertEquals(a1.id, a2.id);
+	}
+
+	@Test
+	public void runMultipleObjectTest() {
+		A a1 = new A("a", 10, 1);
+		a1.a = a1;
+		B b = new B();
+		b.id = 10;
+		b.a = a1;
+		AeroMapper mapper = new AeroMapper.Builder(client).build();
+		mapper.save(a1);
+		mapper.save(b);
+		
+		B b2 = mapper.read(B.class, b.id);
+		assertEquals(b.id, b2.id);
+		assertEquals(b.a.age, b2.a.age);
+		assertEquals(b.a.name, b2.a.name);
+		assertEquals(b.a.id, b2.a.id);
+	}
+}


### PR DESCRIPTION
If an object A has a reference back to itself (ie A.a = this) then
previously this would give stack overflows or hang. This new version
works correctly, but only if batchLoad = true (default). If BatchLoad =
false, then the resolution of the child objects occurs before the
creation of this object, not allowing for a proper replacement strategy.
This has to be the case for constructors to work. Honestly, there is
very look good reason not to use BatchLoad so maybe this should be
deprecated.