### PR TITLE
Javadoc standardization

### DIFF
--- a/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
@@ -191,19 +191,6 @@ public class AeroMapper implements IAeroMapper {
         this.mappingConverter = new MappingConverter(this, mClient);
     }
 
-    /**
-     * Save each object in the database. This method will perform a REPLACE on the existing record so any existing
-     * data will be overwritten by the data in the passed object. This is a convenience method for
-     * <pre>
-     * save(A);
-     * save(B);
-     * save(C);
-     * </pre>
-     * Not that no transactionality is implied by this method -- if any of the save methods fail, the exception will be
-     * thrown without trying the other objects, nor attempting to roll back previously saved objects
-     * @param objects One or two objects to save.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public void save(@NotNull Object... objects) throws AerospikeException {
     	for (Object thisObject : objects) {
@@ -211,29 +198,17 @@ public class AeroMapper implements IAeroMapper {
     	}
     }
 
-    /**
-     * Save an object in the database. This method will perform a REPLACE on the existing record so any existing
-     * data will be overwritten by the data in the passed object
-     * @param object The object to save.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public void save(@NotNull Object object, String... binNames) throws AerospikeException {
         save(null, object, RecordExistsAction.REPLACE, binNames);
     }
 
-    /**
-     * Save an object in the database with the given WritePolicy. This write policy will override any other set writePolicy so
-     * is effectively an upsert operation
-     * @param writePolicy The write policy for the save operation.
-     * @param object The object to save.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public void save(@NotNull WritePolicy writePolicy, @NotNull Object object, String... binNames) throws AerospikeException {
         save(writePolicy, object, null, binNames);
     }
 
+    @SuppressWarnings("unchecked")
     private <T> void save(WritePolicy writePolicy, @NotNull T object, RecordExistsAction recordExistsAction, String[] binNames) {
         Class<T> clazz = (Class<T>) object.getClass();
         ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
@@ -265,32 +240,16 @@ public class AeroMapper implements IAeroMapper {
         mClient.put(writePolicy, key, bins);
     }
 
-    /**
-     * Updates the object in the database, merging the record with the existing record. This uses the RecordExistsAction
-     * of UPDATE. If bins are specified, only bins with the passed names will be updated (or all of them if null is passed)
-     * @param object The object to update.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public void update(@NotNull Object object, String... binNames) throws AerospikeException {
         save(null, object, RecordExistsAction.UPDATE, binNames);
     }
 
-    /**
-     * Read a record from the repository and map it to an instance of the passed class, by providing a digest.
-     * @param clazz - The type of the record.
-     * @param digest - The Aerospike digest (Unique server hash value generated from set name and user key).
-     * @return The returned mapped record.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public <T> T readFromDigest(@NotNull Class<T> clazz, @NotNull byte[] digest) throws AerospikeException {
         return this.readFromDigest(clazz, digest, true);
     }
 
-    /**
-     * This method should not be used except by mappers
-     */
     @Override
     public <T> T readFromDigest(@NotNull Class<T> clazz, @NotNull byte[] digest, boolean resolveDependencies) throws AerospikeException {
         ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
@@ -298,22 +257,11 @@ public class AeroMapper implements IAeroMapper {
         return this.read(null, clazz, key, entry, resolveDependencies);
     }
 
-    /**
-     * Read a record from the repository and map it to an instance of the passed class, by providing a digest.
-     * @param readPolicy - The read policy for the read operation.
-     * @param clazz - The type of the record.
-     * @param digest - The Aerospike digest (Unique server hash value generated from set name and user key).
-     * @return The returned mapped record.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public <T> T readFromDigest(Policy readPolicy, @NotNull Class<T> clazz, @NotNull byte[] digest) throws AerospikeException {
     	return this.readFromDigest(readPolicy, clazz, digest, true);
     }
-    
-    /**
-     * This method should not be used except by mappers
-     */
+
     @Override
     public <T> T readFromDigest(Policy readPolicy, @NotNull Class<T> clazz, @NotNull byte[] digest, boolean resolveDependencies) throws AerospikeException {
         ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
@@ -321,21 +269,11 @@ public class AeroMapper implements IAeroMapper {
         return this.read(readPolicy, clazz, key, entry, resolveDependencies);
     }
 
-    /**
-     * Read a record from the repository and map it to an instance of the passed class.
-     * @param clazz - The type of be returned.
-     * @param userKey - The key of the record. The namespace and set will be derived from the values specified on the passed class.
-     * @return The returned mapped record.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public <T> T read(@NotNull Class<T> clazz, @NotNull Object userKey) throws AerospikeException {
         return this.read(clazz, userKey, true);
     }
 
-    /**
-     * This method should not be used: It is used by mappers to correctly resolved dependencies. Use read(clazz, userKey) instead
-     */
     @Override
     public <T> T read(@NotNull Class<T> clazz, @NotNull Object userKey, boolean resolveDependencies) throws AerospikeException {
         ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
@@ -344,22 +282,11 @@ public class AeroMapper implements IAeroMapper {
         return read(null, clazz, key, entry, resolveDependencies);
     }
 
-    /**
-     * Read a record from the repository and map it to an instance of the passed class.
-     * @param readPolicy - The read policy for the read operation.
-     * @param clazz - The type of be returned.
-     * @param userKey - The key of the record. The namespace and set will be derived from the values specified on the passed class.
-     * @return The returned mapped record.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public <T> T read(Policy readPolicy, @NotNull Class<T> clazz, @NotNull Object userKey) throws AerospikeException {
     	return this.read(readPolicy, clazz, userKey, true);
     }
-    
-    /**
-     * This method should not be used except by mappers
-     */
+
     @Override
     public <T> T read(Policy readPolicy, @NotNull Class<T> clazz, @NotNull Object userKey, boolean resolveDependencies) throws AerospikeException {
         ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
@@ -368,26 +295,11 @@ public class AeroMapper implements IAeroMapper {
         return read(readPolicy, clazz, key, entry, resolveDependencies);
     }
 
-    /**
-     * Read a batch of records from the repository and map them to an instance of the passed class.
-     * @param clazz - The type of be returned.
-     * @param userKeys - The keys of the record. The namespace and set will be derived from the values specified on the passed class.
-     * @return The returned mapped records.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public <T> T[] read(@NotNull Class<T> clazz, @NotNull Object... userKeys) throws AerospikeException {
     	return this.read(null, clazz, userKeys);
     }
 
-    /**
-     * Read a batch of records from the repository and map them to an instance of the passed class.
-     * @param batchPolicy A given batch policy.
-     * @param clazz - The type of be returned.
-     * @param userKeys - The keys of the record. The namespace and set will be derived from the values specified on the passed class.
-     * @return The returned mapped records.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public <T> T[] read(BatchPolicy batchPolicy, @NotNull Class<T> clazz, @NotNull Object... userKeys) throws AerospikeException {
         ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
@@ -433,6 +345,7 @@ public class AeroMapper implements IAeroMapper {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private <T> T[] readBatch(BatchPolicy batchPolicy, @NotNull Class<T> clazz, @NotNull Key[] keys, @NotNull ClassCacheEntry<T> entry) {
     	if (batchPolicy == null) {
     		batchPolicy = entry.getBatchPolicy();
@@ -460,26 +373,11 @@ public class AeroMapper implements IAeroMapper {
         return results;
     }
 
-    /**
-     * Delete a record by specifying a class and a user key.
-     * @param clazz - The type of the record.
-     * @param userKey - The key of the record. The namespace and set will be derived from the values specified on the passed class.
-     * @return whether record existed on server before deletion
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public <T> boolean delete(@NotNull Class<T> clazz, @NotNull Object userKey) throws AerospikeException {
     	return this.delete(null, clazz, userKey);
     }
 
-    /**
-     * Delete a record by specifying a write policy, a class and a user key.
-     * @param writePolicy - The write policy for the delete operation.
-     * @param clazz - The type of the record.
-     * @param userKey - The key of the record. The namespace and set will be derived from the values specified on the passed class.
-     * @return whether record existed on server before deletion
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public <T> boolean delete(WritePolicy writePolicy, @NotNull Class<T> clazz, @NotNull Object userKey) throws AerospikeException {
         ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
@@ -498,24 +396,11 @@ public class AeroMapper implements IAeroMapper {
         return mClient.delete(writePolicy, key);
     }
 
-    /**
-     * Delete a record by specifying an object.
-     * @param object The object to delete.
-     * @return whether record existed on server before deletion
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public boolean delete(@NotNull Object object) throws AerospikeException {
     	return this.delete((WritePolicy)null, object);
     }
 
-    /**
-     * Delete a record by specifying a write policy and an object.
-     * @param writePolicy - The write policy for the delete operation.
-     * @param object The object to delete.
-     * @return whether record existed on server before deletion
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public boolean delete(WritePolicy writePolicy, @NotNull Object object) throws AerospikeException {
         ClassCacheEntry<?> entry = MapperUtils.getEntryAndValidateNamespace(object.getClass(), this);
@@ -530,63 +415,7 @@ public class AeroMapper implements IAeroMapper {
         }
         return mClient.delete(writePolicy, key);
     }
-    
-    /**
-     * Create a virtual list against an attribute on a class. The list does all operations to the database and does not affect the underlying
-     * class, and is useful for situation when operations are needed to affect the database without having to return all the elements on the
-     * list each time.
-     * <p/>
-     * For example, consider a set of transactions associated with a credit card. Common operations might be
-     * <ul>
-     * 	<li>Return the last N transactions </li>
-     * 	<li>insert a new transaction into the list</li>
-     * </ul>
-     * These operation can all be done without having the full set of transactions
-     * @param <T> the type of the elements in the list.
-     * @param object The object that will use as a base for the virtual list.
-     * @param binName The Aerospike bin name.
-     * @param elementClazz The class of the elements in the list.
-     * @return A virtual list.
-     */
-    @Override
-    public <T> VirtualList<T> asBackedList(@NotNull Object object, @NotNull String binName, Class<T> elementClazz) {
-    	return new VirtualList<>(this, object, binName, elementClazz);
-    }
-    
-    /**
-     * Create a virtual list against an attribute on a class. The list does all operations to the database and does not affect the underlying
-     * class, and is useful for situation when operations are needed to affect the database without having to return all the elements on the
-     * list each time.
-     * <p/>
-     * Note that the object being mapped does not need to actually exist in this case. The owning class is used purely for the definitions
-     * of how to map the list elements (are they to be mapped in the database as a list or a map, is each element a list or a map, etc), as
-     * well as using the namespace / set definition for the location to map into the database.  The 
-     * passed key is used to map the object to the database. 
-     * <p/>
-     * For example, consider a set of transactions associated with a credit card. Common operations might be
-     * <ul>
-     * 	<li>Return the last N transactions </li>
-     * 	<li>insert a new transaction into the list</li>
-     * </ul>
-     * These operation can all be done without having the full set of transactions
-     * @param <T> the type of the elements in the list.
-     * @param owningClazz Used for the definitions of how to map the list elements.
-     * @param key The key to map the object to the database.
-     * @param binName The Aerospike bin name.
-     * @param elementClazz The class of the elements in the list.
-     * @return A virtual list.
-     */
-    @Override
-    public <T> VirtualList<T> asBackedList(@NotNull Class<?> owningClazz, @NotNull Object key, @NotNull String binName, Class<T> elementClazz) {
-    	return new VirtualList<>(this, owningClazz, key, binName, elementClazz);
-    }
 
-    /**
-     * Find a record by specifying a class and a Boolean function.
-     * @param clazz - The type of the record.
-     * @param function a Boolean function.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public <T> void find(@NotNull Class<T> clazz, Function<T, Boolean> function) throws AerospikeException {
         ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
@@ -616,71 +445,21 @@ public class AeroMapper implements IAeroMapper {
         }
     }
 
-    /**
-     * Scan every record in the set associated with the passed class. Each record will be converted to the appropriate class then passed to the
-     * processor. If the processor returns true, more records will be processed and if the processor returns false, the scan is aborted.
-     * <p/>
-     * Depending on the ScanPolicy set up for this class, it is possible for the processor to be called by multiple different
-     * threads concurrently, so the processor should be thread-safe
-     *
-     * @param clazz     - the class used to determine which set to scan and to convert the returned records to.
-     * @param processor - the Processor used to process each record
-     */
     @Override
     public <T> void scan(@NotNull Class<T> clazz, @NotNull Processor<T> processor) {
         scan(null, clazz, processor);
     }
 
-    /**
-     * Scan every record in the set associated with the passed class. Each record will be converted to the appropriate class then passed to the
-     * processor. If the processor returns true, more records will be processed and if the processor returns false, the scan is aborted.
-     * <p/>
-     * Depending on the policy passed or set as the ScanPolicy for this class, it is possible for the processor to be called by multiple different
-     * threads concurrently, so the processor should be thread-safe. Note that as a consequence of this, if the processor returns false to abort the
-     * scan there is a chance that records are being concurrently processed in other threads and this processing will not be interrupted.
-     * <p/>
-     *
-     * @param policy    - the scan policy to use. If this is null, the default scan policy of the passed class will be used.
-     * @param clazz     - the class used to determine which set to scan and to convert the returned records to.
-     * @param processor - the Processor used to process each record
-     */
     @Override
     public <T> void scan(ScanPolicy policy, @NotNull Class<T> clazz, @NotNull Processor<T> processor) {
         scan(policy, clazz, processor, -1);
     }
 
-    /**
-     * Scan every record in the set associated with the passed class, limiting the throughput to the specified recordsPerSecond. Each record will be converted
-     * to the appropriate class then passed to the
-     * processor. If the processor returns true, more records will be processed and if the processor returns false, the scan is aborted.
-     * <p/>
-     * Depending on the ScanPolicy set up for this class, it is possible for the processor to be called by multiple different
-     * threads concurrently, so the processor should be thread-safe
-     *
-     * @param clazz            - the class used to determine which set to scan and to convert the returned records to.
-     * @param processor        - the Processor used to process each record
-     * @param recordsPerSecond - the maximum number of records to be processed every second.
-     */
     @Override
     public <T> void scan(@NotNull Class<T> clazz, @NotNull Processor<T> processor, int recordsPerSecond) {
         scan(null, clazz, processor, recordsPerSecond);
     }
 
-    /**
-     * Scan every record in the set associated with the passed class. Each record will be converted to the appropriate class then passed to the
-     * processor. If the processor returns true, more records will be processed and if the processor returns false, the scan is aborted.
-     * <p/>
-     * Depending on the policy passed or set as the ScanPolicy for this class, it is possible for the processor to be called by multiple different
-     * threads concurrently, so the processor should be thread-safe. Note that as a consequence of this, if the processor returns false to abort the
-     * scan there is a chance that records are being concurrently processed in other threads and this processing will not be interrupted.
-     * <p/>
-     *
-     * @param policy           - the scan policy to use. If this is null, the default scan policy of the passed class will be used.
-     * @param clazz            - the class used to determine which set to scan and to convert the returned records to.
-     * @param processor        - the Processor used to process each record
-     * @param recordsPerSecond - the number of records to process per second. Set to 0 for unlimited, &gt; 0 for a finite rate, &lt; 0 for no change
-     *                         (use the value from the passed policy)
-     */
     @Override
     public <T> void scan(ScanPolicy policy, @NotNull Class<T> clazz, @NotNull Processor<T> processor, int recordsPerSecond) {
         ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
@@ -711,34 +490,11 @@ public class AeroMapper implements IAeroMapper {
         }
     }
 
-    /**
-     * Perform a secondary index query with the specified query policy. Each record will be converted
-     * to the appropriate class then passed to the processor. If the processor returns false the query is aborted
-     * whereas if the processor returns true subsequent records (if any) are processed.
-     * <p/>
-     * The query policy used will be the one associated with the passed classtype.
-     *
-     * @param clazz     - the class used to determine which set to scan and to convert the returned records to.
-     * @param processor - the Processor used to process each record
-     * @param filter    - the filter used to determine which secondary index to use. If this filter is null, every record in the set
-     *                  associated with the passed classtype will be scanned, effectively turning the query into a scan
-     */
     @Override
     public <T> void query(@NotNull Class<T> clazz, @NotNull Processor<T> processor, Filter filter) {
         query(null, clazz, processor, filter);
     }
 
-    /**
-     * Perform a secondary index query with the specified query policy. Each record will be converted
-     * to the appropriate class then passed to the processor. If the processor returns false the query is aborted
-     * whereas if the processor returns true subsequent records (if any) are processed.
-     *
-     * @param policy    - The query policy to use. If this parameter is not passed, the query policy associated with the passed classtype will be used
-     * @param clazz     - the class used to determine which set to scan and to convert the returned records to.
-     * @param processor - the Processor used to process each record
-     * @param filter    - the filter used to determine which secondary index to use. If this filter is null, every record in the set
-     *                  associated with the passed classtype will be scanned, effectively turning the query into a scan
-     */
     @Override
     public <T> void query(QueryPolicy policy, @NotNull Class<T> clazz, @NotNull Processor<T> processor, Filter filter) {
         ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
@@ -762,7 +518,17 @@ public class AeroMapper implements IAeroMapper {
             recordSet.close();
         }
     }
-    
+
+    @Override
+    public <T> VirtualList<T> asBackedList(@NotNull Object object, @NotNull String binName, Class<T> elementClazz) {
+        return new VirtualList<>(this, object, binName, elementClazz);
+    }
+
+    @Override
+    public <T> VirtualList<T> asBackedList(@NotNull Class<?> owningClazz, @NotNull Object key, @NotNull String binName, Class<T> elementClazz) {
+        return new VirtualList<>(this, owningClazz, key, binName, elementClazz);
+    }
+
     @Override
     public IAerospikeClient getClient() {
         return this.mClient;
@@ -773,59 +539,34 @@ public class AeroMapper implements IAeroMapper {
         return this.mappingConverter;
     }
 
-    /**
-     * Return the read policy to be used for the passed class. This is a convenience method only and should rarely be needed
-     * @param clazz - the class to return the read policy for.
-     * @return - the appropriate read policy. If none is set, the client's readPolicyDefault is returned.
-     */
+    @Override
+    public IAeroMapper asMapper() {
+        return this;
+    }
+
     @Override
     public Policy getReadPolicy(Class<?> clazz) {
         return getPolicyByClassAndType(clazz, PolicyType.READ);
     }
 
-    /**
-     * Return the write policy to be used for the passed class. This is a convenience method only and should rarely be needed
-     * @param clazz - the class to return the write policy for.
-     * @return - the appropriate write policy. If none is set, the client's writePolicyDefault is returned.
-     */
     @Override
     public WritePolicy getWritePolicy(Class<?> clazz) {
         return (WritePolicy) getPolicyByClassAndType(clazz, PolicyType.WRITE);
     }
 
-    /**
-     * Return the batch policy to be used for the passed class. This is a convenience method only and should rarely be needed
-     * @param clazz - the class to return the batch policy for.
-     * @return - the appropriate batch policy. If none is set, the client's batchPolicyDefault is returned.
-     */
     @Override
     public BatchPolicy getBatchPolicy(Class<?> clazz) {
         return (BatchPolicy) getPolicyByClassAndType(clazz, PolicyType.BATCH);
     }
 
-    /**
-     * Return the scan policy to be used for the passed class. This is a convenience method only and should rarely be needed
-     * @param clazz - the class to return the scan policy for.
-     * @return - the appropriate scan policy. If none is set, the client's scanPolicyDefault is returned.
-     */
     @Override
     public ScanPolicy getScanPolicy(Class<?> clazz) {
         return (ScanPolicy) getPolicyByClassAndType(clazz, PolicyType.SCAN);
     }
 
-    /**
-     * Return the query policy to be used for the passed class. This is a convenience method only and should rarely be needed
-     * @param clazz - the class to return the query policy for.
-     * @return - the appropriate query policy. If none is set, the client's queryPolicyDefault is returned.
-     */
     @Override
     public QueryPolicy getQueryPolicy(Class<?> clazz) {
         return (QueryPolicy) getPolicyByClassAndType(clazz, PolicyType.QUERY);
-    }
-
-    @Override
-    public IAeroMapper asMapper() {
-        return this;
     }
 
     private Policy getPolicyByClassAndType(Class<?> clazz, PolicyType policyType) {

--- a/src/main/java/com/aerospike/mapper/tools/IAeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/IAeroMapper.java
@@ -4,6 +4,7 @@ import java.util.function.Function;
 
 import javax.validation.constraints.NotNull;
 
+import com.aerospike.client.AerospikeException;
 import com.aerospike.client.IAerospikeClient;
 import com.aerospike.client.policy.BatchPolicy;
 import com.aerospike.client.policy.Policy;
@@ -15,59 +16,312 @@ import com.aerospike.mapper.tools.virtuallist.VirtualList;
 
 public interface IAeroMapper extends IBaseAeroMapper {
 
+    /**
+     * Save each object in the database. This method will perform a REPLACE on the existing record so any existing
+     * data will be overwritten by the data in the passed object. This is a convenience method for
+     * <pre>
+     * save(A);
+     * save(B);
+     * save(C);
+     * </pre>
+     * Not that no transactionality is implied by this method -- if any of the save methods fail, the exception will be
+     * thrown without trying the other objects, nor attempting to roll back previously saved objects
+     *
+     * @param objects One or two objects to save.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     void save(@NotNull Object... objects);
 
+    /**
+     * Save an object in the database. This method will perform a REPLACE on the existing record so any existing
+     * data will be overwritten by the data in the passed object
+     *
+     * @param object The object to save.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     void save(@NotNull Object object, String... binNames);
 
+    /**
+     * Save an object in the database with the given WritePolicy. This write policy will override any other set writePolicy so
+     * is effectively an upsert operation
+     *
+     * @param writePolicy The write policy for the save operation.
+     * @param object      The object to save.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     void save(@NotNull WritePolicy writePolicy, @NotNull Object object, String... binNames);
 
+    /**
+     * Updates the object in the database, merging the record with the existing record. This uses the RecordExistsAction
+     * of UPDATE. If bins are specified, only bins with the passed names will be updated (or all of them if null is passed)
+     *
+     * @param object The object to update.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     void update(@NotNull Object object, String... binNames);
 
+    /**
+     * Read a record from the repository and map it to an instance of the passed class, by providing a digest.
+     *
+     * @param clazz  - The type of the record.
+     * @param digest - The Aerospike digest (Unique server hash value generated from set name and user key).
+     * @return The returned mapped record.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> T readFromDigest(@NotNull Class<T> clazz, @NotNull byte[] digest);
 
+    /**
+     * This method should not be used: It is used by mappers to correctly resolved dependencies.
+     */
     <T> T readFromDigest(@NotNull Class<T> clazz, @NotNull byte[] digest, boolean resolveDependencies);
 
+    /**
+     * Read a record from the repository and map it to an instance of the passed class, by providing a digest.
+     *
+     * @param readPolicy - The read policy for the read operation.
+     * @param clazz      - The type of the record.
+     * @param digest     - The Aerospike digest (Unique server hash value generated from set name and user key).
+     * @return The returned mapped record.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> T readFromDigest(Policy readPolicy, @NotNull Class<T> clazz, @NotNull byte[] digest);
 
+    /**
+     * This method should not be used: It is used by mappers to correctly resolved dependencies.
+     */
     <T> T readFromDigest(Policy readPolicy, @NotNull Class<T> clazz, @NotNull byte[] digest, boolean resolveDependencies);
 
+    /**
+     * Read a record from the repository and map it to an instance of the passed class.
+     *
+     * @param clazz   - The type of be returned.
+     * @param userKey - The key of the record. The namespace and set will be derived from the values specified on the passed class.
+     * @return The returned mapped record.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> T read(@NotNull Class<T> clazz, @NotNull Object userKey);
 
+    /**
+     * This method should not be used: It is used by mappers to correctly resolved dependencies.
+     */
     <T> T read(@NotNull Class<T> clazz, @NotNull Object userKey, boolean resolveDependencies);
 
+    /**
+     * Read a record from the repository and map it to an instance of the passed class.
+     *
+     * @param readPolicy - The read policy for the read operation.
+     * @param clazz      - The type of be returned.
+     * @param userKey    - The key of the record. The namespace and set will be derived from the values specified on the passed class.
+     * @return The returned mapped record.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> T read(Policy readPolicy, @NotNull Class<T> clazz, @NotNull Object userKey);
 
+    /**
+     * This method should not be used: It is used by mappers to correctly resolved dependencies.
+     */
     <T> T read(Policy readPolicy, @NotNull Class<T> clazz, @NotNull Object userKey, boolean resolveDependencies);
 
+    /**
+     * Read a batch of records from the repository and map them to an instance of the passed class.
+     *
+     * @param clazz    - The type of be returned.
+     * @param userKeys - The keys of the record. The namespace and set will be derived from the values specified on the passed class.
+     * @return The returned mapped records.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> T[] read(@NotNull Class<T> clazz, @NotNull Object... userKeys);
 
+    /**
+     * Read a batch of records from the repository and map them to an instance of the passed class.
+     *
+     * @param batchPolicy A given batch policy.
+     * @param clazz       - The type of be returned.
+     * @param userKeys    - The keys of the record. The namespace and set will be derived from the values specified on the passed class.
+     * @return The returned mapped records.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> T[] read(BatchPolicy batchPolicy, @NotNull Class<T> clazz, @NotNull Object... userKeys);
 
+    /**
+     * Delete a record by specifying a class and a user key.
+     *
+     * @param clazz   - The type of the record.
+     * @param userKey - The key of the record. The namespace and set will be derived from the values specified on the passed class.
+     * @return whether record existed on server before deletion
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> boolean delete(@NotNull Class<T> clazz, @NotNull Object userKey);
 
+    /**
+     * Delete a record by specifying a write policy, a class and a user key.
+     *
+     * @param writePolicy - The write policy for the delete operation.
+     * @param clazz       - The type of the record.
+     * @param userKey     - The key of the record. The namespace and set will be derived from the values specified on the passed class.
+     * @return whether record existed on server before deletion
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> boolean delete(WritePolicy writePolicy, @NotNull Class<T> clazz, @NotNull Object userKey);
 
+    /**
+     * Delete a record by specifying an object.
+     *
+     * @param object The object to delete.
+     * @return whether record existed on server before deletion
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     boolean delete(@NotNull Object object);
 
+    /**
+     * Delete a record by specifying a write policy and an object.
+     *
+     * @param writePolicy - The write policy for the delete operation.
+     * @param object      The object to delete.
+     * @return whether record existed on server before deletion
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     boolean delete(WritePolicy writePolicy, @NotNull Object object);
 
-    <T> VirtualList<T> asBackedList(@NotNull Object object, @NotNull String binName, Class<T> elementClazz);
-
-    <T> VirtualList<T> asBackedList(@NotNull Class<?> owningClazz, @NotNull Object key, @NotNull String binName, Class<T> elementClazz);
-
+    /**
+     * Find a record by specifying a class and a Boolean function.
+     *
+     * @param clazz    - The type of the record.
+     * @param function a Boolean function.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> void find(@NotNull Class<T> clazz, Function<T, Boolean> function);
 
-    IAerospikeClient getClient();
-
-    <T> void query(@NotNull Class<T> clazz, @NotNull Processor<T> processor, Filter filter);
-
-    <T> void query(QueryPolicy policy, @NotNull Class<T> clazz, @NotNull Processor<T> processor, Filter filter);
-
+    /**
+     * Scan every record in the set associated with the passed class. Each record will be converted to the appropriate class then passed to the
+     * processor. If the processor returns true, more records will be processed and if the processor returns false, the scan is aborted.
+     * <p/>
+     * Depending on the ScanPolicy set up for this class, it is possible for the processor to be called by multiple different
+     * threads concurrently, so the processor should be thread-safe
+     *
+     * @param clazz     - the class used to determine which set to scan and to convert the returned records to.
+     * @param processor - the Processor used to process each record
+     */
     <T> void scan(@NotNull Class<T> clazz, @NotNull Processor<T> processor);
 
+    /**
+     * Scan every record in the set associated with the passed class. Each record will be converted to the appropriate class then passed to the
+     * processor. If the processor returns true, more records will be processed and if the processor returns false, the scan is aborted.
+     * <p/>
+     * Depending on the policy passed or set as the ScanPolicy for this class, it is possible for the processor to be called by multiple different
+     * threads concurrently, so the processor should be thread-safe. Note that as a consequence of this, if the processor returns false to abort the
+     * scan there is a chance that records are being concurrently processed in other threads and this processing will not be interrupted.
+     * <p/>
+     *
+     * @param policy    - the scan policy to use. If this is null, the default scan policy of the passed class will be used.
+     * @param clazz     - the class used to determine which set to scan and to convert the returned records to.
+     * @param processor - the Processor used to process each record
+     */
     <T> void scan(ScanPolicy policy, @NotNull Class<T> clazz, @NotNull Processor<T> processor);
 
+    /**
+     * Scan every record in the set associated with the passed class, limiting the throughput to the specified recordsPerSecond. Each record will be converted
+     * to the appropriate class then passed to the
+     * processor. If the processor returns true, more records will be processed and if the processor returns false, the scan is aborted.
+     * <p/>
+     * Depending on the ScanPolicy set up for this class, it is possible for the processor to be called by multiple different
+     * threads concurrently, so the processor should be thread-safe
+     *
+     * @param clazz            - the class used to determine which set to scan and to convert the returned records to.
+     * @param processor        - the Processor used to process each record
+     * @param recordsPerSecond - the maximum number of records to be processed every second.
+     */
     <T> void scan(@NotNull Class<T> clazz, @NotNull Processor<T> processor, int recordsPerSecond);
 
+    /**
+     * Scan every record in the set associated with the passed class. Each record will be converted to the appropriate class then passed to the
+     * processor. If the processor returns true, more records will be processed and if the processor returns false, the scan is aborted.
+     * <p/>
+     * Depending on the policy passed or set as the ScanPolicy for this class, it is possible for the processor to be called by multiple different
+     * threads concurrently, so the processor should be thread-safe. Note that as a consequence of this, if the processor returns false to abort the
+     * scan there is a chance that records are being concurrently processed in other threads and this processing will not be interrupted.
+     * <p/>
+     *
+     * @param policy           - the scan policy to use. If this is null, the default scan policy of the passed class will be used.
+     * @param clazz            - the class used to determine which set to scan and to convert the returned records to.
+     * @param processor        - the Processor used to process each record
+     * @param recordsPerSecond - the number of records to process per second. Set to 0 for unlimited, &gt; 0 for a finite rate, &lt; 0 for no change
+     *                         (use the value from the passed policy)
+     */
     <T> void scan(ScanPolicy policy, @NotNull Class<T> clazz, @NotNull Processor<T> processor, int recordsPerSecond);
+
+    /**
+     * Perform a secondary index query with the specified query policy. Each record will be converted
+     * to the appropriate class then passed to the processor. If the processor returns false the query is aborted
+     * whereas if the processor returns true subsequent records (if any) are processed.
+     * <p/>
+     * The query policy used will be the one associated with the passed classtype.
+     *
+     * @param clazz     - the class used to determine which set to scan and to convert the returned records to.
+     * @param processor - the Processor used to process each record
+     * @param filter    - the filter used to determine which secondary index to use. If this filter is null, every record in the set
+     *                  associated with the passed classtype will be scanned, effectively turning the query into a scan
+     */
+    <T> void query(@NotNull Class<T> clazz, @NotNull Processor<T> processor, Filter filter);
+
+    /**
+     * Perform a secondary index query with the specified query policy. Each record will be converted
+     * to the appropriate class then passed to the processor. If the processor returns false the query is aborted
+     * whereas if the processor returns true subsequent records (if any) are processed.
+     *
+     * @param policy    - The query policy to use. If this parameter is not passed, the query policy associated with the passed classtype will be used
+     * @param clazz     - the class used to determine which set to scan and to convert the returned records to.
+     * @param processor - the Processor used to process each record
+     * @param filter    - the filter used to determine which secondary index to use. If this filter is null, every record in the set
+     *                  associated with the passed classtype will be scanned, effectively turning the query into a scan
+     */
+    <T> void query(QueryPolicy policy, @NotNull Class<T> clazz, @NotNull Processor<T> processor, Filter filter);
+
+    /**
+     * Create a virtual list against an attribute on a class. The list does all operations to the database and does not affect the underlying
+     * class, and is useful for situation when operations are needed to affect the database without having to return all the elements on the
+     * list each time.
+     * <p/>
+     * For example, consider a set of transactions associated with a credit card. Common operations might be
+     * <ul>
+     * 	<li>Return the last N transactions </li>
+     * 	<li>insert a new transaction into the list</li>
+     * </ul>
+     * These operation can all be done without having the full set of transactions
+     *
+     * @param <T>          the type of the elements in the list.
+     * @param object       The object that will use as a base for the virtual list.
+     * @param binName      The Aerospike bin name.
+     * @param elementClazz The class of the elements in the list.
+     * @return A virtual list.
+     */
+    <T> VirtualList<T> asBackedList(@NotNull Object object, @NotNull String binName, Class<T> elementClazz);
+
+    /**
+     * Create a virtual list against an attribute on a class. The list does all operations to the database and does not affect the underlying
+     * class, and is useful for situation when operations are needed to affect the database without having to return all the elements on the
+     * list each time.
+     * <p/>
+     * Note that the object being mapped does not need to actually exist in this case. The owning class is used purely for the definitions
+     * of how to map the list elements (are they to be mapped in the database as a list or a map, is each element a list or a map, etc), as
+     * well as using the namespace / set definition for the location to map into the database.  The
+     * passed key is used to map the object to the database.
+     * <p/>
+     * For example, consider a set of transactions associated with a credit card. Common operations might be
+     * <ul>
+     * 	<li>Return the last N transactions </li>
+     * 	<li>insert a new transaction into the list</li>
+     * </ul>
+     * These operation can all be done without having the full set of transactions
+     *
+     * @param <T>          the type of the elements in the list.
+     * @param owningClazz  Used for the definitions of how to map the list elements.
+     * @param key          The key to map the object to the database.
+     * @param binName      The Aerospike bin name.
+     * @param elementClazz The class of the elements in the list.
+     * @return A virtual list.
+     */
+    <T> VirtualList<T> asBackedList(@NotNull Class<?> owningClazz, @NotNull Object key, @NotNull String binName, Class<T> elementClazz);
+
+    IAerospikeClient getClient();
 }

--- a/src/main/java/com/aerospike/mapper/tools/IBaseAeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/IBaseAeroMapper.java
@@ -8,17 +8,48 @@ import com.aerospike.client.policy.QueryPolicy;
 import com.aerospike.mapper.tools.converters.MappingConverter;
 
 public interface IBaseAeroMapper {
-    Policy getReadPolicy(Class<?> clazz);
 
-    WritePolicy getWritePolicy(Class<?> clazz);
-
-    BatchPolicy getBatchPolicy(Class<?> clazz);
-
-    ScanPolicy getScanPolicy(Class<?> clazz);
-
-    QueryPolicy getQueryPolicy(Class<?> clazz);
+    MappingConverter getMappingConverter();
 
     IAeroMapper asMapper();
 
-    MappingConverter getMappingConverter();
+    /**
+     * Return the read policy to be used for the passed class. This is a convenience method only and should rarely be needed
+     *
+     * @param clazz - the class to return the read policy for.
+     * @return - the appropriate read policy. If none is set, the client's readPolicyDefault is returned.
+     */
+    Policy getReadPolicy(Class<?> clazz);
+
+    /**
+     * Return the write policy to be used for the passed class. This is a convenience method only and should rarely be needed
+     *
+     * @param clazz - the class to return the write policy for.
+     * @return - the appropriate write policy. If none is set, the client's writePolicyDefault is returned.
+     */
+    WritePolicy getWritePolicy(Class<?> clazz);
+
+    /**
+     * Return the batch policy to be used for the passed class. This is a convenience method only and should rarely be needed
+     *
+     * @param clazz - the class to return the batch policy for.
+     * @return - the appropriate batch policy. If none is set, the client's batchPolicyDefault is returned.
+     */
+    BatchPolicy getBatchPolicy(Class<?> clazz);
+
+    /**
+     * Return the scan policy to be used for the passed class. This is a convenience method only and should rarely be needed
+     *
+     * @param clazz - the class to return the scan policy for.
+     * @return - the appropriate scan policy. If none is set, the client's scanPolicyDefault is returned.
+     */
+    ScanPolicy getScanPolicy(Class<?> clazz);
+
+    /**
+     * Return the query policy to be used for the passed class. This is a convenience method only and should rarely be needed
+     *
+     * @param clazz - the class to return the query policy for.
+     * @return - the appropriate query policy. If none is set, the client's queryPolicyDefault is returned.
+     */
+    QueryPolicy getQueryPolicy(Class<?> clazz);
 }

--- a/src/main/java/com/aerospike/mapper/tools/IReactiveAeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/IReactiveAeroMapper.java
@@ -1,5 +1,6 @@
 package com.aerospike.mapper.tools;
 
+import com.aerospike.client.AerospikeException;
 import com.aerospike.client.policy.*;
 import com.aerospike.client.query.Filter;
 import com.aerospike.client.reactor.IAerospikeReactorClient;
@@ -12,59 +13,286 @@ import java.util.function.Function;
 
 public interface IReactiveAeroMapper extends IBaseAeroMapper {
 
+    /**
+     * Save each object in the database. This method will perform a REPLACE on the existing record so any existing
+     * data will be overwritten by the data in the passed object. This is a convenience method for
+     * <pre>
+     * save(A);
+     * save(B);
+     * save(C);
+     * </pre>
+     * Not that no transactionality is implied by this method -- if any of the save methods fail, the exception will be
+     * thrown without trying the other objects, nor attempting to roll back previously saved objects
+     *
+     * @param objects One or two objects to save.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> Flux<T> save(@NotNull T... objects);
 
+    /**
+     * Save an object in the database. This method will perform a REPLACE on the existing record so any existing
+     * data will be overwritten by the data in the passed object
+     *
+     * @param object The object to save.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> Mono<T> save(@NotNull T object, String... binNames);
 
+    /**
+     * Save an object in the database with the given WritePolicy. This write policy will override any other set writePolicy so
+     * is effectively an upsert operation
+     *
+     * @param writePolicy The write policy for the save operation.
+     * @param object      The object to save.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> Mono<T> save(@NotNull WritePolicy writePolicy, @NotNull T object, String... binNames);
 
+    /**
+     * Updates the object in the database, merging the record with the existing record. This uses the RecordExistsAction
+     * of UPDATE. If bins are specified, only bins with the passed names will be updated (or all of them if null is passed)
+     *
+     * @param object The object to update.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> Mono<T> update(@NotNull T object, String... binNames);
 
+    /**
+     * Read a record from the repository and map it to an instance of the passed class, by providing a digest.
+     *
+     * @param clazz  - The type of the record.
+     * @param digest - The Aerospike digest (Unique server hash value generated from set name and user key).
+     * @return The returned mapped record.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> Mono<T> readFromDigest(@NotNull Class<T> clazz, @NotNull byte[] digest);
 
+    /**
+     * This method should not be used: It is used by mappers to correctly resolved dependencies.
+     */
     <T> Mono<T> readFromDigest(@NotNull Class<T> clazz, @NotNull byte[] digest, boolean resolveDependencies);
 
+    /**
+     * Read a record from the repository and map it to an instance of the passed class, by providing a digest.
+     *
+     * @param readPolicy - The read policy for the read operation.
+     * @param clazz      - The type of the record.
+     * @param digest     - The Aerospike digest (Unique server hash value generated from set name and user key).
+     * @return The returned mapped record.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> Mono<T> readFromDigest(Policy readPolicy, @NotNull Class<T> clazz, @NotNull byte[] digest);
 
+    /**
+     * This method should not be used: It is used by mappers to correctly resolved dependencies.
+     */
     <T> Mono<T> readFromDigest(Policy readPolicy, @NotNull Class<T> clazz, @NotNull byte[] digest, boolean resolveDependencies);
 
+    /**
+     * Read a record from the repository and map it to an instance of the passed class.
+     *
+     * @param clazz   - The type of the record.
+     * @param userKey - The key of the record. The namespace and set will be derived from the values specified on the passed class.
+     * @return The returned mapped record.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> Mono<T> read(@NotNull Class<T> clazz, @NotNull Object userKey);
 
+    /**
+     * This method should not be used: It is used by mappers to correctly resolved dependencies.
+     */
     <T> Mono<T> read(@NotNull Class<T> clazz, @NotNull Object userKey, boolean resolveDependencies);
 
+    /**
+     * Read a record from the repository and map it to an instance of the passed class.
+     *
+     * @param readPolicy - The read policy for the read operation.
+     * @param clazz      - The type of the record.
+     * @param userKey    - The key of the record. The namespace and set will be derived from the values specified on the passed class.
+     * @return The returned mapped record.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> Mono<T> read(Policy readPolicy, @NotNull Class<T> clazz, @NotNull Object userKey);
 
+    /**
+     * This method should not be used: It is used by mappers to correctly resolved dependencies.
+     */
     <T> Mono<T> read(Policy readPolicy, @NotNull Class<T> clazz, @NotNull Object userKey, boolean resolveDependencies);
 
+    /**
+     * Read a batch of records from the repository and map them to an instance of the passed class.
+     *
+     * @param clazz    - The type of the record.
+     * @param userKeys - The keys of the record. The namespace and set will be derived from the values specified on the passed class.
+     * @return The returned mapped records.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> Flux<T> read(@NotNull Class<T> clazz, @NotNull Object... userKeys);
 
+    /**
+     * Read a batch of records from the repository and map them to an instance of the passed class.
+     *
+     * @param batchPolicy A given batch policy.
+     * @param clazz       - The type of the record.
+     * @param userKeys    - The keys of the record. The namespace and set will be derived from the values specified on the passed class.
+     * @return The returned mapped records.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> Flux<T> read(BatchPolicy batchPolicy, @NotNull Class<T> clazz, @NotNull Object... userKeys);
 
+    /**
+     * Delete a record by specifying a class and a user key.
+     *
+     * @param clazz   - The type of the record.
+     * @param userKey - The key of the record. The namespace and set will be derived from the values specified on the passed class.
+     * @return whether record existed on server before deletion
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> Mono<Boolean> delete(@NotNull Class<T> clazz, @NotNull Object userKey);
 
+    /**
+     * Delete a record by specifying a write policy, a class and a user key.
+     *
+     * @param writePolicy - The write policy for the delete operation.
+     * @param clazz       - The type of the record.
+     * @param userKey     - The key of the record. The namespace and set will be derived from the values specified on the passed class.
+     * @return whether record existed on server before deletion
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> Mono<Boolean> delete(WritePolicy writePolicy, @NotNull Class<T> clazz, @NotNull Object userKey);
 
+    /**
+     * Delete a record by specifying an object.
+     *
+     * @param object The object to delete.
+     * @return whether record existed on server before deletion
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     Mono<Boolean> delete(@NotNull Object object);
 
+    /**
+     * Delete a record by specifying a write policy and an object.
+     *
+     * @param writePolicy - The write policy for the delete operation.
+     * @param object      The object to delete.
+     * @return whether record existed on server before deletion
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     Mono<Boolean> delete(WritePolicy writePolicy, @NotNull Object object);
 
-    <T> ReactiveVirtualList<T> asBackedList(@NotNull Object object, @NotNull String binName, Class<T> elementClazz);
-
-    <T> ReactiveVirtualList<T> asBackedList(@NotNull Class<?> owningClazz, @NotNull Object key, @NotNull String binName, Class<T> elementClazz);
-
+    /**
+     * Find a record by specifying a class and a Boolean function.
+     *
+     * @param clazz    - The type of the record.
+     * @param function a Boolean function.
+     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
+     */
     <T> Mono<Void> find(@NotNull Class<T> clazz, Function<T, Boolean> function);
 
-    IAerospikeReactorClient getReactorClient();
-
-    <T> Flux<T> query(@NotNull Class<T> clazz, Filter filter);
-
-    <T> Flux<T> query(QueryPolicy policy, @NotNull Class<T> clazz, Filter filter);
-
+    /**
+     * Scan every record in the set associated with the passed class. Each record will be converted to the appropriate class.
+     *
+     * @param clazz - the class used to determine which set to scan and to convert the returned records to.
+     */
     <T> Flux<T> scan(@NotNull Class<T> clazz);
 
+    /**
+     * Scan every record in the set associated with the passed class. Each record will be converted to the appropriate class.
+     *
+     * @param policy - the scan policy to use. If this is null, the default scan policy of the passed class will be used.
+     * @param clazz  - the class used to determine which set to scan and to convert the returned records to.
+     */
     <T> Flux<T> scan(ScanPolicy policy, @NotNull Class<T> clazz);
 
+    /**
+     * Scan every record in the set associated with the passed class, limiting the throughput to the specified recordsPerSecond. Each record will be converted
+     * to the appropriate class.
+     *
+     * @param clazz            - the class used to determine which set to scan and to convert the returned records to.
+     * @param recordsPerSecond - the maximum number of records to be processed every second.
+     */
     <T> Flux<T> scan(@NotNull Class<T> clazz, int recordsPerSecond);
 
+    /**
+     * Scan every record in the set associated with the passed class. Each record will be converted to the appropriate class.
+     *
+     * @param policy           - the scan policy to use. If this is null, the default scan policy of the passed class will be used.
+     * @param clazz            - the class used to determine which set to scan and to convert the returned records to.
+     * @param recordsPerSecond - the number of records to process per second. Set to 0 for unlimited, &gt; 0 for a finite rate, &lt; 0 for no change
+     *                         (use the value from the passed policy)
+     */
     <T> Flux<T> scan(ScanPolicy policy, @NotNull Class<T> clazz, int recordsPerSecond);
+
+    /**
+     * Perform a secondary index query with the specified query policy. Each record will be converted
+     * to the appropriate class then passed to the processor. If the processor returns false the query is aborted
+     * whereas if the processor returns true subsequent records (if any) are processed.
+     * <p/>
+     * The query policy used will be the one associated with the passed classtype.
+     *
+     * @param clazz  - the class used to determine which set to scan and to convert the returned records to.
+     * @param filter - the filter used to determine which secondary index to use. If this filter is null, every record in the set
+     *               associated with the passed classtype will be scanned, effectively turning the query into a scan
+     */
+    <T> Flux<T> query(@NotNull Class<T> clazz, Filter filter);
+
+    /**
+     * Perform a secondary index query with the specified query policy. Each record will be converted
+     * to the appropriate class then passed to the processor. If the processor returns false the query is aborted
+     * whereas if the processor returns true subsequent records (if any) are processed.
+     *
+     * @param policy - The query policy to use. If this parameter is not passed, the query policy associated with the passed classtype will be used
+     * @param clazz  - the class used to determine which set to scan and to convert the returned records to.
+     * @param filter - the filter used to determine which secondary index to use. If this filter is null, every record in the set
+     *               associated with the passed classtype will be scanned, effectively turning the query into a scan
+     */
+    <T> Flux<T> query(QueryPolicy policy, @NotNull Class<T> clazz, Filter filter);
+
+    /**
+     * Create a reactive virtual list against an attribute on a class. The list does all operations to the database and does not affect the underlying
+     * class, and is useful for situation when operations are needed to affect the database without having to return all the elements on the
+     * list each time.
+     * <p/>
+     * For example, consider a set of transactions associated with a credit card. Common operations might be
+     * <ul>
+     * 	<li>Return the last N transactions </li>
+     * 	<li>insert a new transaction into the list</li>
+     * </ul>
+     * These operation can all be done without having the full set of transactions
+     *
+     * @param <T>          the type of the elements in the list.
+     * @param object       The object that will use as a base for the virtual list.
+     * @param binName      The Aerospike bin name.
+     * @param elementClazz The class of the elements in the list.
+     * @return A reactive virtual list.
+     */
+    <T> ReactiveVirtualList<T> asBackedList(@NotNull Object object, @NotNull String binName, Class<T> elementClazz);
+
+    /**
+     * Create a reactive virtual list against an attribute on a class. The list does all operations to the database and does not affect the underlying
+     * class, and is useful for situation when operations are needed to affect the database without having to return all the elements on the
+     * list each time.
+     * <p/>
+     * Note that the object being mapped does not need to actually exist in this case. The owning class is used purely for the definitions
+     * of how to map the list elements (are they to be mapped in the database as a list or a map, is each element a list or a map, etc), as
+     * well as using the namespace / set definition for the location to map into the database.  The
+     * passed key is used to map the object to the database.
+     * <p/>
+     * For example, consider a set of transactions associated with a credit card. Common operations might be
+     * <ul>
+     * 	<li>Return the last N transactions </li>
+     * 	<li>insert a new transaction into the list</li>
+     * </ul>
+     * These operation can all be done without having the full set of transactions
+     *
+     * @param <T>          the type of the elements in the list.
+     * @param owningClazz  Used for the definitions of how to map the list elements.
+     * @param key          The key to map the object to the database.
+     * @param binName      The Aerospike bin name.
+     * @param elementClazz The class of the elements in the list.
+     * @return A reactive virtual list.
+     */
+    <T> ReactiveVirtualList<T> asBackedList(@NotNull Class<?> owningClazz, @NotNull Object key, @NotNull String binName, Class<T> elementClazz);
+
+    IAerospikeReactorClient getReactorClient();
 }

--- a/src/main/java/com/aerospike/mapper/tools/ReactiveAeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/ReactiveAeroMapper.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 public class ReactiveAeroMapper implements IReactiveAeroMapper {
@@ -170,506 +169,23 @@ public class ReactiveAeroMapper implements IReactiveAeroMapper {
         this.mappingConverter = new MappingConverter(this, reactorClient.getAerospikeClient());
     }
 
-    /**
-     * Save each object in the database. This method will perform a REPLACE on the existing record so any existing
-     * data will be overwritten by the data in the passed object. This is a convenience method for
-     * <pre>
-     * save(A);
-     * save(B);
-     * save(C);
-     * </pre>
-     * Not that no transactionality is implied by this method -- if any of the save methods fail, the exception will be
-     * thrown without trying the other objects, nor attempting to roll back previously saved objects
-     * @param objects One or two objects to save.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public <T> Flux<T> save(@NotNull T... objects) {
         return Flux.fromStream(Arrays.stream(objects))
                 .flatMap(this::save);
     }
 
-    /**
-     * Save an object in the database. This method will perform a REPLACE on the existing record so any existing
-     * data will be overwritten by the data in the passed object
-     * @param object The object to save.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public <T> Mono<T> save(@NotNull T object, String... binNames) {
         return save(null, object, RecordExistsAction.REPLACE, binNames);
     }
 
-    /**
-     * Save an object in the database with the given WritePolicy. This write policy will override any other set writePolicy so
-     * is effectively an upsert operation
-     * @param writePolicy The write policy for the save operation.
-     * @param object The object to save.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
     @Override
     public <T> Mono<T> save(@NotNull WritePolicy writePolicy, @NotNull T object, String... binNames) {
         return save(writePolicy, object, null, binNames);
     }
 
-    /**
-     * Updates the object in the database, merging the record with the existing record. This uses the RecordExistsAction
-     * of UPDATE. If bins are specified, only bins with the passed names will be updated (or all of them if null is passed)
-     * @param object The object to update.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
-    @Override
-    public <T> Mono<T> update(@NotNull T object, String... binNames) {
-        return save(null, object, RecordExistsAction.UPDATE, binNames);
-    }
-
-    /**
-     * Read a record from the repository and map it to an instance of the passed class, by providing a digest.
-     * @param clazz - The type of the record.
-     * @param digest - The Aerospike digest (Unique server hash value generated from set name and user key).
-     * @return The returned mapped record.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
-    @Override
-    public <T> Mono<T> readFromDigest(@NotNull Class<T> clazz, @NotNull byte[] digest) {
-        return this.readFromDigest(clazz, digest, true);
-    }
-
-    /**
-     * This method should not be used except by mappers
-     */
-    @Override
-    public <T> Mono<T> readFromDigest(@NotNull Class<T> clazz, @NotNull byte[] digest, boolean resolveDependencies) throws AerospikeException {
-        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
-        Key key = new Key(entry.getNamespace(), digest, entry.getSetName(), null);
-        return this.read(null, clazz, key, entry, resolveDependencies);
-    }
-
-    /**
-     * Read a record from the repository and map it to an instance of the passed class, by providing a digest.
-     * @param readPolicy - The read policy for the read operation.
-     * @param clazz - The type of the record.
-     * @param digest - The Aerospike digest (Unique server hash value generated from set name and user key).
-     * @return The returned mapped record.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
-    @Override
-    public <T> Mono<T> readFromDigest(Policy readPolicy, @NotNull Class<T> clazz, @NotNull byte[] digest) {
-        return this.readFromDigest(readPolicy, clazz, digest, true);
-    }
-
-    /**
-     * This method should not be used except by mappers
-     */
-    @Override
-    public <T> Mono<T> readFromDigest(Policy readPolicy, @NotNull Class<T> clazz, @NotNull byte[] digest, boolean resolveDependencies) {
-        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
-        Key key = new Key(entry.getNamespace(), digest, entry.getSetName(), null);
-        return this.read(readPolicy, clazz, key, entry, resolveDependencies);
-    }
-
-    /**
-     * Read a record from the repository and map it to an instance of the passed class.
-     * @param clazz - The type of the record.
-     * @param userKey - The key of the record. The namespace and set will be derived from the values specified on the passed class.
-     * @return The returned mapped record.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
-    @Override
-    public <T> Mono<T> read(@NotNull Class<T> clazz, @NotNull Object userKey) {
-        return this.read(clazz, userKey, true);
-    }
-
-    /**
-     * This method should not be used: It is used by mappers to correctly resolved dependencies. Use read(clazz, userKey) instead
-     */
-    @Override
-    public <T> Mono<T> read(@NotNull Class<T> clazz, @NotNull Object userKey, boolean resolveDependencies) {
-        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
-        String set = entry.getSetName();
-        Key key = new Key(entry.getNamespace(), set, Value.get(entry.translateKeyToAerospikeKey(userKey)));
-        return read(null, clazz, key, entry, resolveDependencies);
-    }
-
-    /**
-     * Read a record from the repository and map it to an instance of the passed class.
-     * @param readPolicy - The read policy for the read operation.
-     * @param clazz - The type of the record.
-     * @param userKey - The key of the record. The namespace and set will be derived from the values specified on the passed class.
-     * @return The returned mapped record.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
-    @Override
-    public <T> Mono<T> read(Policy readPolicy, @NotNull Class<T> clazz, @NotNull Object userKey) {
-        return this.read(readPolicy, clazz, userKey, true);
-    }
-
-    /**
-     * This method should not be used except by mappers
-     */
-    @Override
-    public <T> Mono<T> read(Policy readPolicy, @NotNull Class<T> clazz, @NotNull Object userKey, boolean resolveDependencies) {
-        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
-        String set = entry.getSetName();
-        Key key = new Key(entry.getNamespace(), set, Value.get(entry.translateKeyToAerospikeKey(userKey)));
-        return read(readPolicy, clazz, key, entry, resolveDependencies);
-    }
-
-    /**
-     * Read a batch of records from the repository and map them to an instance of the passed class.
-     * @param clazz - The type of the record.
-     * @param userKeys - The keys of the record. The namespace and set will be derived from the values specified on the passed class.
-     * @return The returned mapped records.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
-    @Override
-    public <T> Flux<T> read(@NotNull Class<T> clazz, @NotNull Object... userKeys) {
-        throw new UnsupportedOperationException("Batch reading is not supported in ReactiveAeroMapper yet.");
-        //return this.read(null, clazz, userKeys);
-    }
-
-    /**
-     * Read a batch of records from the repository and map them to an instance of the passed class.
-     * @param batchPolicy A given batch policy.
-     * @param clazz - The type of the record.
-     * @param userKeys - The keys of the record. The namespace and set will be derived from the values specified on the passed class.
-     * @return The returned mapped records.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
-    @Override
-    public <T> Flux<T> read(BatchPolicy batchPolicy, @NotNull Class<T> clazz, @NotNull Object... userKeys) {
-        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
-        String set = entry.getSetName();
-        Key[] keys = new Key[userKeys.length];
-        for (int i = 0; i < userKeys.length; i++) {
-            if (userKeys[i] == null) {
-                throw new AerospikeException("Cannot pass null to object " + i + " in multi-read call");
-            }
-            else {
-                keys[i] = new Key(entry.getNamespace(), set, Value.get(entry.translateKeyToAerospikeKey(userKeys[i])));
-            }
-        }
-
-        return readBatch(batchPolicy, clazz, keys, entry);
-    }
-
-    /**
-     * Delete a record by specifying a class and a user key.
-     * @param clazz - The type of the record.
-     * @param userKey - The key of the record. The namespace and set will be derived from the values specified on the passed class.
-     * @return whether record existed on server before deletion
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
-    @Override
-    public <T> Mono<Boolean> delete(@NotNull Class<T> clazz, @NotNull Object userKey) {
-        return this.delete(null, clazz, userKey);
-    }
-
-    /**
-     * Delete a record by specifying a write policy, a class and a user key.
-     * @param writePolicy - The write policy for the delete operation.
-     * @param clazz - The type of the record.
-     * @param userKey - The key of the record. The namespace and set will be derived from the values specified on the passed class.
-     * @return whether record existed on server before deletion
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
-    @Override
-    public <T> Mono<Boolean> delete(WritePolicy writePolicy, @NotNull Class<T> clazz, @NotNull Object userKey) {
-        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
-        Object asKey = entry.translateKeyToAerospikeKey(userKey);
-
-        if (writePolicy == null) {
-            writePolicy = entry.getWritePolicy();
-            if (entry.getDurableDelete() != null) {
-                // Clone the write policy so we're not changing the original one
-                writePolicy = new WritePolicy(writePolicy);
-                writePolicy.durableDelete = entry.getDurableDelete();
-            }
-        }
-        Key key = new Key(entry.getNamespace(), entry.getSetName(), Value.get(asKey));
-
-        return reactorClient
-                .delete(writePolicy, key)
-                .map(k -> true);
-    }
-
-    /**
-     * Delete a record by specifying an object.
-     * @param object The object to delete.
-     * @return whether record existed on server before deletion
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
-    @Override
-    public Mono<Boolean> delete(@NotNull Object object) {
-        return this.delete((WritePolicy)null, object);
-    }
-
-    /**
-     * Delete a record by specifying a write policy and an object.
-     * @param writePolicy - The write policy for the delete operation.
-     * @param object The object to delete.
-     * @return whether record existed on server before deletion
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
-    @Override
-    public Mono<Boolean> delete(WritePolicy writePolicy, @NotNull Object object) {
-        ClassCacheEntry<?> entry = MapperUtils.getEntryAndValidateNamespace(object.getClass(), this);
-        Key key = new Key(entry.getNamespace(), entry.getSetName(), Value.get(entry.getKey(object)));
-
-        if (writePolicy == null) {
-            writePolicy = entry.getWritePolicy();
-            if (entry.getDurableDelete() != null) {
-                writePolicy = new WritePolicy(writePolicy);
-                writePolicy.durableDelete = entry.getDurableDelete();
-            }
-        }
-        return reactorClient
-                .delete(writePolicy, key)
-                .map(k -> true);
-    }
-
-    /**
-     * Create a reactive virtual list against an attribute on a class. The list does all operations to the database and does not affect the underlying
-     * class, and is useful for situation when operations are needed to affect the database without having to return all the elements on the
-     * list each time.
-     * <p/>
-     * For example, consider a set of transactions associated with a credit card. Common operations might be
-     * <ul>
-     * 	<li>Return the last N transactions </li>
-     * 	<li>insert a new transaction into the list</li>
-     * </ul>
-     * These operation can all be done without having the full set of transactions
-     * @param <T> the type of the elements in the list.
-     * @param object The object that will use as a base for the virtual list.
-     * @param binName The Aerospike bin name.
-     * @param elementClazz The class of the elements in the list.
-     * @return A reactive virtual list.
-     */
-    @Override
-    public <T> ReactiveVirtualList<T> asBackedList(@NotNull Object object, @NotNull String binName, Class<T> elementClazz) {
-        return new ReactiveVirtualList<>(this, object, binName, elementClazz);
-    }
-
-    /**
-     * Create a reactive virtual list against an attribute on a class. The list does all operations to the database and does not affect the underlying
-     * class, and is useful for situation when operations are needed to affect the database without having to return all the elements on the
-     * list each time.
-     * <p/>
-     * Note that the object being mapped does not need to actually exist in this case. The owning class is used purely for the definitions
-     * of how to map the list elements (are they to be mapped in the database as a list or a map, is each element a list or a map, etc), as
-     * well as using the namespace / set definition for the location to map into the database.  The
-     * passed key is used to map the object to the database.
-     * <p/>
-     * For example, consider a set of transactions associated with a credit card. Common operations might be
-     * <ul>
-     * 	<li>Return the last N transactions </li>
-     * 	<li>insert a new transaction into the list</li>
-     * </ul>
-     * These operation can all be done without having the full set of transactions
-     * @param <T> the type of the elements in the list.
-     * @param owningClazz Used for the definitions of how to map the list elements.
-     * @param key The key to map the object to the database.
-     * @param binName The Aerospike bin name.
-     * @param elementClazz The class of the elements in the list.
-     * @return A reactive virtual list.
-     */
-    @Override
-    public <T> ReactiveVirtualList<T> asBackedList(@NotNull Class<?> owningClazz, @NotNull Object key, @NotNull String binName, Class<T> elementClazz) {
-        return new ReactiveVirtualList<>(this, owningClazz, key, binName, elementClazz);
-    }
-
-    /**
-     * Find a record by specifying a class and a Boolean function.
-     * @param clazz - The type of the record.
-     * @param function a Boolean function.
-     * @throws AerospikeException an AerospikeException will be thrown in case of an error.
-     */
-    @Override
-    public <T> Mono<Void> find(@NotNull Class<T> clazz, Function<T, Boolean> function) throws AerospikeException {
-        return Mono.fromCallable(() -> {
-            asMapper().find(clazz, function);
-            return null;
-        });
-    }
-
-    /**
-     * Scan every record in the set associated with the passed class. Each record will be converted to the appropriate class.
-     *
-     * @param clazz - the class used to determine which set to scan and to convert the returned records to.
-     */
-    @Override
-    public <T> Flux<T> scan(@NotNull Class<T> clazz) {
-        return scan(null, clazz);
-    }
-
-    /**
-     * Scan every record in the set associated with the passed class. Each record will be converted to the appropriate class.
-     *
-     * @param policy - the scan policy to use. If this is null, the default scan policy of the passed class will be used.
-     * @param clazz  - the class used to determine which set to scan and to convert the returned records to.
-     */
-    @Override
-    public <T> Flux<T> scan(ScanPolicy policy, @NotNull Class<T> clazz) {
-        return scan(policy, clazz, -1);
-    }
-
-    /**
-     * Scan every record in the set associated with the passed class, limiting the throughput to the specified recordsPerSecond. Each record will be converted
-     * to the appropriate class.
-     *
-     * @param clazz            - the class used to determine which set to scan and to convert the returned records to.
-     * @param recordsPerSecond - the maximum number of records to be processed every second.
-     */
-    @Override
-    public <T> Flux<T> scan(@NotNull Class<T> clazz, int recordsPerSecond) {
-        return scan(null, clazz, recordsPerSecond);
-    }
-
-    /**
-     * Scan every record in the set associated with the passed class. Each record will be converted to the appropriate class.
-     *
-     * @param policy           - the scan policy to use. If this is null, the default scan policy of the passed class will be used.
-     * @param clazz            - the class used to determine which set to scan and to convert the returned records to.
-     * @param recordsPerSecond - the number of records to process per second. Set to 0 for unlimited, &gt; 0 for a finite rate, &lt; 0 for no change
-     *                         (use the value from the passed policy)
-     */
-    @Override
-    public <T> Flux<T> scan(ScanPolicy policy, @NotNull Class<T> clazz, int recordsPerSecond) {
-        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
-        if (policy == null) {
-            policy = entry.getScanPolicy();
-        }
-        if (recordsPerSecond >= 0) {
-            // Ensure the underlying rate on the policy does not change
-            policy = new ScanPolicy(policy);
-            policy.recordsPerSecond = recordsPerSecond;
-        }
-        String namespace = entry.getNamespace();
-        String setName = entry.getSetName();
-
-        return reactorClient.scanAll(policy, namespace, setName)
-                .map(keyRecord -> this.getMappingConverter().convertToObject(clazz, keyRecord.record));
-    }
-
-    /**
-     * Perform a secondary index query with the specified query policy. Each record will be converted
-     * to the appropriate class then passed to the processor. If the processor returns false the query is aborted
-     * whereas if the processor returns true subsequent records (if any) are processed.
-     * <p/>
-     * The query policy used will be the one associated with the passed classtype.
-     *
-     * @param clazz  - the class used to determine which set to scan and to convert the returned records to.
-     * @param filter - the filter used to determine which secondary index to use. If this filter is null, every record in the set
-     *               associated with the passed classtype will be scanned, effectively turning the query into a scan
-     */
-    @Override
-    public <T> Flux<T> query(@NotNull Class<T> clazz, Filter filter) {
-        return query(null, clazz, filter);
-    }
-
-    /**
-     * Perform a secondary index query with the specified query policy. Each record will be converted
-     * to the appropriate class then passed to the processor. If the processor returns false the query is aborted
-     * whereas if the processor returns true subsequent records (if any) are processed.
-     *
-     * @param policy - The query policy to use. If this parameter is not passed, the query policy associated with the passed classtype will be used
-     * @param clazz  - the class used to determine which set to scan and to convert the returned records to.
-     * @param filter - the filter used to determine which secondary index to use. If this filter is null, every record in the set
-     *               associated with the passed classtype will be scanned, effectively turning the query into a scan
-     */
-    @Override
-    public <T> Flux<T> query(QueryPolicy policy, @NotNull Class<T> clazz, Filter filter) {
-        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
-        if (policy == null) {
-            policy = entry.getQueryPolicy();
-        }
-        Statement statement = new Statement();
-        statement.setFilter(filter);
-        statement.setNamespace(entry.getNamespace());
-        statement.setSetName(entry.getSetName());
-
-        return reactorClient.query(policy, statement)
-                .map(keyRecord -> this.getMappingConverter().convertToObject(clazz, keyRecord.record));
-    }
-
-    @Override
-    public IAerospikeReactorClient getReactorClient() {
-        return this.reactorClient;
-    }
-
-    @Override
-    public MappingConverter getMappingConverter() {
-        return this.mappingConverter;
-    }
-
-    /**
-     * Return the read policy to be used for the passed class. This is a convenience method only and should rarely be needed
-     * @param clazz - the class to return the read policy for.
-     * @return - the appropriate read policy. If none is set, the client's readPolicyDefault is returned.
-     */
-    @Override
-    public Policy getReadPolicy(Class<?> clazz) {
-        return getPolicyByClassAndType(clazz, ClassCache.PolicyType.READ);
-    }
-
-    /**
-     * Return the write policy to be used for the passed class. This is a convenience method only and should rarely be needed
-     * @param clazz - the class to return the write policy for.
-     * @return - the appropriate write policy. If none is set, the client's writePolicyDefault is returned.
-     */
-    @Override
-    public WritePolicy getWritePolicy(Class<?> clazz) {
-        return (WritePolicy) getPolicyByClassAndType(clazz, ClassCache.PolicyType.WRITE);
-    }
-
-    /**
-     * Return the batch policy to be used for the passed class. This is a convenience method only and should rarely be needed
-     * @param clazz - the class to return the batch policy for.
-     * @return - the appropriate batch policy. If none is set, the client's batchPolicyDefault is returned.
-     */
-    @Override
-    public BatchPolicy getBatchPolicy(Class<?> clazz) {
-        return (BatchPolicy) getPolicyByClassAndType(clazz, ClassCache.PolicyType.BATCH);
-    }
-
-    /**
-     * Return the scan policy to be used for the passed class. This is a convenience method only and should rarely be needed
-     * @param clazz - the class to return the scan policy for.
-     * @return - the appropriate scan policy. If none is set, the client's scanPolicyDefault is returned.
-     */
-    @Override
-    public ScanPolicy getScanPolicy(Class<?> clazz) {
-        return (ScanPolicy) getPolicyByClassAndType(clazz, ClassCache.PolicyType.SCAN);
-    }
-
-    /**
-     * Return the query policy to be used for the passed class. This is a convenience method only and should rarely be needed
-     * @param clazz - the class to return the query policy for.
-     * @return - the appropriate query policy. If none is set, the client's queryPolicyDefault is returned.
-     */
-    @Override
-    public QueryPolicy getQueryPolicy(Class<?> clazz) {
-        return (QueryPolicy) getPolicyByClassAndType(clazz, ClassCache.PolicyType.QUERY);
-    }
-
-    @Override
-    public IAeroMapper asMapper() {
-        return aeroMapper;
-    }
-
-    private Policy getPolicyByClassAndType(Class<?> clazz, ClassCache.PolicyType policyType) {
-        ClassCacheEntry<?> entry = ClassCache.getInstance().loadClass(clazz, this);
-
-        switch (policyType) {
-            case READ: return entry == null ? reactorClient.getReadPolicyDefault() : entry.getReadPolicy();
-            case WRITE: return entry == null ? reactorClient.getWritePolicyDefault() : entry.getWritePolicy();
-            case BATCH: return entry == null ? reactorClient.getBatchPolicyDefault() : entry.getBatchPolicy();
-            case SCAN: return entry == null ? reactorClient.getScanPolicyDefault() : entry.getScanPolicy();
-            case QUERY: return entry == null ? reactorClient.getQueryPolicyDefault() : entry.getQueryPolicy();
-            default: throw new UnsupportedOperationException("Provided unsupported policy.");
-        }
-    }
-
+    @SuppressWarnings("unchecked")
     private <T> Mono<T> save(WritePolicy writePolicy, @NotNull T object, RecordExistsAction recordExistsAction, String[] binNames) {
         Class<T> clazz = (Class<T>) object.getClass();
         ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
@@ -704,6 +220,84 @@ public class ReactiveAeroMapper implements IReactiveAeroMapper {
                 .onErrorMap(this::translateError);
     }
 
+    @Override
+    public <T> Mono<T> update(@NotNull T object, String... binNames) {
+        return save(null, object, RecordExistsAction.UPDATE, binNames);
+    }
+
+    @Override
+    public <T> Mono<T> readFromDigest(@NotNull Class<T> clazz, @NotNull byte[] digest) {
+        return this.readFromDigest(clazz, digest, true);
+    }
+
+    @Override
+    public <T> Mono<T> readFromDigest(@NotNull Class<T> clazz, @NotNull byte[] digest, boolean resolveDependencies) throws AerospikeException {
+        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
+        Key key = new Key(entry.getNamespace(), digest, entry.getSetName(), null);
+        return this.read(null, clazz, key, entry, resolveDependencies);
+    }
+
+    @Override
+    public <T> Mono<T> readFromDigest(Policy readPolicy, @NotNull Class<T> clazz, @NotNull byte[] digest) {
+        return this.readFromDigest(readPolicy, clazz, digest, true);
+    }
+
+    @Override
+    public <T> Mono<T> readFromDigest(Policy readPolicy, @NotNull Class<T> clazz, @NotNull byte[] digest, boolean resolveDependencies) {
+        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
+        Key key = new Key(entry.getNamespace(), digest, entry.getSetName(), null);
+        return this.read(readPolicy, clazz, key, entry, resolveDependencies);
+    }
+
+    @Override
+    public <T> Mono<T> read(@NotNull Class<T> clazz, @NotNull Object userKey) {
+        return this.read(clazz, userKey, true);
+    }
+
+    @Override
+    public <T> Mono<T> read(@NotNull Class<T> clazz, @NotNull Object userKey, boolean resolveDependencies) {
+        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
+        String set = entry.getSetName();
+        Key key = new Key(entry.getNamespace(), set, Value.get(entry.translateKeyToAerospikeKey(userKey)));
+        return read(null, clazz, key, entry, resolveDependencies);
+    }
+
+    @Override
+    public <T> Mono<T> read(Policy readPolicy, @NotNull Class<T> clazz, @NotNull Object userKey) {
+        return this.read(readPolicy, clazz, userKey, true);
+    }
+
+    @Override
+    public <T> Mono<T> read(Policy readPolicy, @NotNull Class<T> clazz, @NotNull Object userKey, boolean resolveDependencies) {
+        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
+        String set = entry.getSetName();
+        Key key = new Key(entry.getNamespace(), set, Value.get(entry.translateKeyToAerospikeKey(userKey)));
+        return read(readPolicy, clazz, key, entry, resolveDependencies);
+    }
+
+    @Override
+    public <T> Flux<T> read(@NotNull Class<T> clazz, @NotNull Object... userKeys) {
+        throw new UnsupportedOperationException("Batch reading is not supported in ReactiveAeroMapper yet.");
+        //return this.read(null, clazz, userKeys);
+    }
+
+    @Override
+    public <T> Flux<T> read(BatchPolicy batchPolicy, @NotNull Class<T> clazz, @NotNull Object... userKeys) {
+        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
+        String set = entry.getSetName();
+        Key[] keys = new Key[userKeys.length];
+        for (int i = 0; i < userKeys.length; i++) {
+            if (userKeys[i] == null) {
+                throw new AerospikeException("Cannot pass null to object " + i + " in multi-read call");
+            }
+            else {
+                keys[i] = new Key(entry.getNamespace(), set, Value.get(entry.translateKeyToAerospikeKey(userKeys[i])));
+            }
+        }
+
+        return readBatch(batchPolicy, clazz, keys, entry);
+    }
+
     private <T> Mono<T> read(Policy readPolicy, @NotNull Class<T> clazz, @NotNull Key key, @NotNull ClassCacheEntry<T> entry, boolean resolveDependencies) {
         if (readPolicy == null) {
             readPolicy = entry.getReadPolicy();
@@ -733,18 +327,189 @@ public class ReactiveAeroMapper implements IReactiveAeroMapper {
                 .getFlux(batchPolicy, keys)
                 .filter(keyRecord -> Objects.nonNull(keyRecord.record))
                 .map(keyRecord -> {
-                        try {
-                            ThreadLocalKeySaver.save(keyRecord.key);
-                            return mappingConverter.convertToObject(clazz, keyRecord.record, entry, false);
-                        } catch (ReflectiveOperationException e) {
-                            throw new AerospikeException(e);
-                        } finally {
-                            ThreadLocalKeySaver.clear();
-                        }
+                    try {
+                        ThreadLocalKeySaver.save(keyRecord.key);
+                        return mappingConverter.convertToObject(clazz, keyRecord.record, entry, false);
+                    } catch (ReflectiveOperationException e) {
+                        throw new AerospikeException(e);
+                    } finally {
+                        ThreadLocalKeySaver.clear();
+                    }
                 });
 
         mappingConverter.resolveDependencies(entry);
         return results;
+    }
+
+    @Override
+    public <T> Mono<Boolean> delete(@NotNull Class<T> clazz, @NotNull Object userKey) {
+        return this.delete(null, clazz, userKey);
+    }
+
+    @Override
+    public <T> Mono<Boolean> delete(WritePolicy writePolicy, @NotNull Class<T> clazz, @NotNull Object userKey) {
+        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
+        Object asKey = entry.translateKeyToAerospikeKey(userKey);
+
+        if (writePolicy == null) {
+            writePolicy = entry.getWritePolicy();
+            if (entry.getDurableDelete() != null) {
+                // Clone the write policy so we're not changing the original one
+                writePolicy = new WritePolicy(writePolicy);
+                writePolicy.durableDelete = entry.getDurableDelete();
+            }
+        }
+        Key key = new Key(entry.getNamespace(), entry.getSetName(), Value.get(asKey));
+
+        return reactorClient
+                .delete(writePolicy, key)
+                .map(k -> true);
+    }
+
+    @Override
+    public Mono<Boolean> delete(@NotNull Object object) {
+        return this.delete((WritePolicy)null, object);
+    }
+
+    @Override
+    public Mono<Boolean> delete(WritePolicy writePolicy, @NotNull Object object) {
+        ClassCacheEntry<?> entry = MapperUtils.getEntryAndValidateNamespace(object.getClass(), this);
+        Key key = new Key(entry.getNamespace(), entry.getSetName(), Value.get(entry.getKey(object)));
+
+        if (writePolicy == null) {
+            writePolicy = entry.getWritePolicy();
+            if (entry.getDurableDelete() != null) {
+                writePolicy = new WritePolicy(writePolicy);
+                writePolicy.durableDelete = entry.getDurableDelete();
+            }
+        }
+        return reactorClient
+                .delete(writePolicy, key)
+                .map(k -> true);
+    }
+
+    @Override
+    public <T> Mono<Void> find(@NotNull Class<T> clazz, Function<T, Boolean> function) throws AerospikeException {
+        return Mono.fromCallable(() -> {
+            asMapper().find(clazz, function);
+            return null;
+        });
+    }
+
+    @Override
+    public <T> Flux<T> scan(@NotNull Class<T> clazz) {
+        return scan(null, clazz);
+    }
+
+    @Override
+    public <T> Flux<T> scan(ScanPolicy policy, @NotNull Class<T> clazz) {
+        return scan(policy, clazz, -1);
+    }
+
+    @Override
+    public <T> Flux<T> scan(@NotNull Class<T> clazz, int recordsPerSecond) {
+        return scan(null, clazz, recordsPerSecond);
+    }
+
+    @Override
+    public <T> Flux<T> scan(ScanPolicy policy, @NotNull Class<T> clazz, int recordsPerSecond) {
+        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
+        if (policy == null) {
+            policy = entry.getScanPolicy();
+        }
+        if (recordsPerSecond >= 0) {
+            // Ensure the underlying rate on the policy does not change
+            policy = new ScanPolicy(policy);
+            policy.recordsPerSecond = recordsPerSecond;
+        }
+        String namespace = entry.getNamespace();
+        String setName = entry.getSetName();
+
+        return reactorClient.scanAll(policy, namespace, setName)
+                .map(keyRecord -> this.getMappingConverter().convertToObject(clazz, keyRecord.record));
+    }
+
+    @Override
+    public <T> Flux<T> query(@NotNull Class<T> clazz, Filter filter) {
+        return query(null, clazz, filter);
+    }
+
+    @Override
+    public <T> Flux<T> query(QueryPolicy policy, @NotNull Class<T> clazz, Filter filter) {
+        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
+        if (policy == null) {
+            policy = entry.getQueryPolicy();
+        }
+        Statement statement = new Statement();
+        statement.setFilter(filter);
+        statement.setNamespace(entry.getNamespace());
+        statement.setSetName(entry.getSetName());
+
+        return reactorClient.query(policy, statement)
+                .map(keyRecord -> this.getMappingConverter().convertToObject(clazz, keyRecord.record));
+    }
+
+    @Override
+    public <T> ReactiveVirtualList<T> asBackedList(@NotNull Object object, @NotNull String binName, Class<T> elementClazz) {
+        return new ReactiveVirtualList<>(this, object, binName, elementClazz);
+    }
+
+    @Override
+    public <T> ReactiveVirtualList<T> asBackedList(@NotNull Class<?> owningClazz, @NotNull Object key, @NotNull String binName, Class<T> elementClazz) {
+        return new ReactiveVirtualList<>(this, owningClazz, key, binName, elementClazz);
+    }
+
+    @Override
+    public IAerospikeReactorClient getReactorClient() {
+        return this.reactorClient;
+    }
+
+    @Override
+    public MappingConverter getMappingConverter() {
+        return this.mappingConverter;
+    }
+
+    @Override
+    public IAeroMapper asMapper() {
+        return aeroMapper;
+    }
+
+    @Override
+    public Policy getReadPolicy(Class<?> clazz) {
+        return getPolicyByClassAndType(clazz, ClassCache.PolicyType.READ);
+    }
+
+    @Override
+    public WritePolicy getWritePolicy(Class<?> clazz) {
+        return (WritePolicy) getPolicyByClassAndType(clazz, ClassCache.PolicyType.WRITE);
+    }
+
+    @Override
+    public BatchPolicy getBatchPolicy(Class<?> clazz) {
+        return (BatchPolicy) getPolicyByClassAndType(clazz, ClassCache.PolicyType.BATCH);
+    }
+
+    @Override
+    public ScanPolicy getScanPolicy(Class<?> clazz) {
+        return (ScanPolicy) getPolicyByClassAndType(clazz, ClassCache.PolicyType.SCAN);
+    }
+
+    @Override
+    public QueryPolicy getQueryPolicy(Class<?> clazz) {
+        return (QueryPolicy) getPolicyByClassAndType(clazz, ClassCache.PolicyType.QUERY);
+    }
+
+    private Policy getPolicyByClassAndType(Class<?> clazz, ClassCache.PolicyType policyType) {
+        ClassCacheEntry<?> entry = ClassCache.getInstance().loadClass(clazz, this);
+
+        switch (policyType) {
+            case READ: return entry == null ? reactorClient.getReadPolicyDefault() : entry.getReadPolicy();
+            case WRITE: return entry == null ? reactorClient.getWritePolicyDefault() : entry.getWritePolicy();
+            case BATCH: return entry == null ? reactorClient.getBatchPolicyDefault() : entry.getBatchPolicy();
+            case SCAN: return entry == null ? reactorClient.getScanPolicyDefault() : entry.getScanPolicy();
+            case QUERY: return entry == null ? reactorClient.getQueryPolicyDefault() : entry.getQueryPolicy();
+            default: throw new UnsupportedOperationException("Provided unsupported policy.");
+        }
     }
 
     private Throwable translateError(Throwable e) {

--- a/src/main/java/com/aerospike/mapper/tools/converters/MappingConverter.java
+++ b/src/main/java/com/aerospike/mapper/tools/converters/MappingConverter.java
@@ -37,6 +37,7 @@ public class MappingConverter {
     /**
      * Translate a Java object to an Aerospike format object. Note that this could potentially have performance issues as
      * the type information of the passed object must be determined on every call.
+     *
      * @param obj A given Java object.
      * @return An Aerospike format object.
      */
@@ -51,6 +52,7 @@ public class MappingConverter {
     /**
      * Translate an Aerospike object to a Java object. Note that this could potentially have performance issues as
      * the type information of the passed object must be determined on every call.
+     *
      * @param obj A given Java object.
      * @return An Aerospike format object.
      */
@@ -66,10 +68,12 @@ public class MappingConverter {
     // The following are convenience methods to convert objects to / from lists / maps / records in case
     // it is needed to perform this operation manually. They will not be needed in most use cases.
     // --------------------------------------------------------------------------------------------------
+
     /**
      * Given a record loaded from Aerospike and a class type, attempt to convert the record to
      * an instance of the passed class.
-     * @param clazz The class type to convert the Aerospike record to.
+     *
+     * @param clazz  The class type to convert the Aerospike record to.
      * @param record The Aerospike record to convert.
      * @return A virtual list.
      * @throws AerospikeException an AerospikeException will be thrown in case of an encountering a ReflectiveOperationException.
@@ -85,9 +89,10 @@ public class MappingConverter {
     /**
      * Given a record loaded from Aerospike and a class type, attempt to convert the record to
      * an instance of the passed class.
-     * @param clazz The class type to convert the Aerospike record to.
+     *
+     * @param clazz  The class type to convert the Aerospike record to.
      * @param record The Aerospike record to convert.
-     * @param entry The entry that holds information on how to store the provided class.
+     * @param entry  The entry that holds information on how to store the provided class.
      * @return A virtual list.
      * @throws AerospikeException an AerospikeException will be thrown in case of an encountering a ReflectiveOperationException.
      */
@@ -112,7 +117,8 @@ public class MappingConverter {
     /**
      * Given a list of records loaded from Aerospike and a class type, attempt to convert the records to
      * an instance of the passed class.
-     * @param clazz The class type to convert the Aerospike record to.
+     *
+     * @param clazz  The class type to convert the Aerospike record to.
      * @param record The Aerospike records to convert.
      * @return A virtual list.
      * @throws AerospikeException an AerospikeException will be thrown in case of an encountering a ReflectiveOperationException.
@@ -142,7 +148,8 @@ public class MappingConverter {
     /**
      * Given a map of records loaded from Aerospike and a class type, attempt to convert the records to
      * an instance of the passed class.
-     * @param clazz The class type to convert the Aerospike record to.
+     *
+     * @param clazz  The class type to convert the Aerospike record to.
      * @param record The Aerospike records to convert.
      * @return A virtual list.
      * @throws AerospikeException an AerospikeException will be thrown in case of an encountering a ReflectiveOperationException.
@@ -154,9 +161,11 @@ public class MappingConverter {
 
     /**
      * Given an instance of a class (of any type), convert its properties to a list
+     *
      * @param instance The instance of a class (of any type).
      * @return a List of the properties of the given instance.
      */
+    @SuppressWarnings("unchecked")
     public <T> List<Object> convertToList(@NotNull T instance) {
         ClassCacheEntry<T> entry = (ClassCacheEntry<T>) ClassCache.getInstance().loadClass(instance.getClass(), mapper);
         return entry.getList(instance, false, false);
@@ -165,9 +174,11 @@ public class MappingConverter {
     /**
      * Given an instance of a class (of any type), convert its properties to a map, properties names will use as the
      * key and properties values will be the values.
+     *
      * @param instance The instance of a class (of any type).
      * @return the properties {@link Map} of the given instance.
      */
+    @SuppressWarnings("unchecked")
     public <T> Map<String, Object> convertToMap(@NotNull T instance) {
         ClassCacheEntry<T> entry = (ClassCacheEntry<T>) ClassCache.getInstance().loadClass(instance.getClass(), mapper);
         return entry.getMap(instance, false);
@@ -180,6 +191,7 @@ public class MappingConverter {
             return new Key(entry.getNamespace(), entry.getSetName(), Value.get(entry.translateKeyToAerospikeKey(deferredObject.getKey())));
         }
     }
+
     /**
      * If an object refers to other objects (eg A has a list of B via references), then reading the object will populate the
      * ids. If configured to do so, these objects can be loaded via a batch load and populated back into the references which
@@ -190,6 +202,7 @@ public class MappingConverter {
      * the list of deferred objects is empty. The deferred objects are stored in a <pre>ThreadLocalData<pre> list, so are thread safe
      * @param parentEntity - the ClassCacheEntry of the parent entity. This is used to get the batch policy to use.
      */
+    @SuppressWarnings("unchecked")
     public void resolveDependencies(ClassCacheEntry<?> parentEntity) {
         List<DeferredObjectLoader.DeferredObjectSetter> deferredObjects = DeferredObjectLoader.getAndClear();
 

--- a/src/main/java/com/aerospike/mapper/tools/virtuallist/IReactiveVirtualList.java
+++ b/src/main/java/com/aerospike/mapper/tools/virtuallist/IReactiveVirtualList.java
@@ -8,115 +8,607 @@ import java.util.List;
 
 public interface IReactiveVirtualList<E> {
 
+    /**
+     * Get items from the list matching the specified value.
+     *
+     * @param value               The value to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given value.
+     */
     Mono<E> getByValue(Object value, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified value.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param value               The value to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given value.
+     */
     Mono<E> getByValue(WritePolicy writePolicy, Object value, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
+     * the start value and end value will dictate the range of values to get,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
+     * <p/>
+     *
+     * @param startValue          Start value of the range to get.
+     * @param endValue            End value of the range to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given value range.
+     */
     Mono<E> getByValueRange(Object startValue, Object endValue, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
+     * the start value and end value will dictate the range of values to get,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
+     * <p/>
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param startValue          Start value of the range to get.
+     * @param endValue            End value of the range to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given value range.
+     */
     Mono<E> getByValueRange(WritePolicy writePolicy, Object startValue, Object endValue, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified list of values.
+     *
+     * @param values              The list of values to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given list of values.
+     */
     Mono<E> getByValueList(List<Object> values, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified list of values.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param values              The list of values to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given list of values.
+     */
     Mono<E> getByValueList(WritePolicy writePolicy, List<Object> values, ReturnType returnResultsOfType);
 
+    /**
+     * Get items nearest to value and greater by relative rank.
+     *
+     * @param value               The value to base the relative rank range calculation on.
+     * @param rank                The relative rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of records that matches the given value and rank.
+     */
     Mono<E> getByValueRelativeRankRange(Object value, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Get items nearest to value and greater by relative rank.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param value               The value to base the relative rank range calculation on.
+     * @param rank                The relative rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of records that matches the given value and rank.
+     */
     Mono<E> getByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Get items nearest to value and greater by relative rank with a count limit.
+     *
+     * @param value               The value to base the relative rank range calculation on.
+     * @param rank                The relative rank.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of records that matches the given value, rank and count.
+     */
     Mono<E> getByValueRelativeRankRange(Object value, int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Get items nearest to value and greater by relative rank with a count limit.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param value               The value to base the relative rank range calculation on.
+     * @param rank                The relative rank.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of records that matches the given value, rank and count.
+     */
     Mono<E> getByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Get items starting at specified index to the end of virtual list.
+     *
+     * @param index               The start index to get items from to the end of the virtual list.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given index.
+     */
     Mono<E> getByIndexRange(int index, ReturnType returnResultsOfType);
 
+    /**
+     * Get items starting at specified index to the end of virtual list.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param index               The start index to get items from to the end of the virtual list.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given index.
+     */
     Mono<E> getByIndexRange(WritePolicy writePolicy, int index, ReturnType returnResultsOfType);
 
+    /**
+     * Get "count" items starting at specified index.
+     *
+     * @param index               The start index to get the "count" items from.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given index and count.
+     */
     Mono<E> getByIndexRange(int index, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Get "count" items starting at specified index.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param index               The start index to get the "count" items from.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given index and count.
+     */
     Mono<E> getByIndexRange(WritePolicy writePolicy, int index, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Get items identified by rank.
+     *
+     * @param rank                The rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given rank.
+     */
     Mono<E> getByRank(int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Get items identified by rank.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param rank                The rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given rank.
+     */
     Mono<E> getByRank(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Get items starting at specified rank to the last ranked item.
+     *
+     * @param rank                The starting rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given rank.
+     */
     Mono<E> getByRankRange(int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Get items starting at specified rank to the last ranked item.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param rank                The starting rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given rank.
+     */
     Mono<E> getByRankRange(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Get "count" items starting at specified rank to the last ranked item.
+     *
+     * @param rank                The starting rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given rank and count.
+     */
     Mono<E> getByRankRange(int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Get "count" items starting at specified rank to the last ranked item.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param rank                The starting rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given rank and count.
+     */
     Mono<E> getByRankRange(WritePolicy writePolicy, int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
+     * It will get the matching key.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, it will get the matching value.
+     * <p/>
+     *
+     * @param key                 Key to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given key range.
+     */
     Mono<E> getByKey(Object key, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
+     * It will get the matching key.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, it will get the matching value.
+     * <p/>
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param key                 Key to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given key range.
+     */
     Mono<E> getByKey(WritePolicy writePolicy, Object key, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified key range. If the list is mapped to a MAP in Aerospike,
+     * the start key and end key will dictate the range of keys to get,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
+     * <p/>
+     *
+     * @param startKey            Start key of the range to get.
+     * @param endKey              End key of the range to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given key range.
+     */
     Mono<E> getByKeyRange(Object startKey, Object endKey, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified key range. If the list is mapped to a MAP in Aerospike,
+     * the start key and end key will dictate the range of keys to get,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
+     * <p/>
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param startKey            Start key of the range to get.
+     * @param endKey              End key of the range to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given key range.
+     */
     Mono<E> getByKeyRange(WritePolicy writePolicy, Object startKey, Object endKey, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
+     * the key will dictate the map key to be removed.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the given key will use as the value to remove from the list.
+     * <p/>
+     *
+     * @param key                 Key to remove.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByKey(Object key, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
+     * the key will dictate the map key to be removed.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the given key will use as the value to remove from the list.
+     * <p/>
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param key                 Key to remove.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByKey(WritePolicy writePolicy, Object key, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items identified by value and returns the removed data.
+     *
+     * @param value               The value to base the items to remove on.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByValue(Object value, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items identified by value and returns the removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param value               The value to base the items to remove on.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByValue(WritePolicy writePolicy, Object value, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items identified by list of values and returns the removed data.
+     *
+     * @param values              The list of values to base the items to remove on.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByValueList(List<Object> values, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items identified by list of values and returns the removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param values              The list of values to base the items to remove on.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByValueList(WritePolicy writePolicy, List<Object> values, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
+     * the start value and end value will dictate the range of values to be removed,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to removed from the list.
+     * <p/>
+     *
+     * @param startValue          Start value of the range to remove.
+     * @param endValue            End value of the range to remove.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByValueRange(Object startValue, Object endValue, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
+     * the start value and end value will dictate the range of values to be removed,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to be removed from the list.
+     * <p/>
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param startValue          Start value of the range to remove.
+     * @param endValue            End value of the range to remove.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByValueRange(WritePolicy writePolicy, Object startValue, Object endValue, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items nearest to value and greater by relative rank.
+     *
+     * @param value               The value to base the items to remove on.
+     * @param rank                The rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByValueRelativeRankRange(Object value, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items nearest to value and greater by relative rank.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param value               The value to base the items to remove on.
+     * @param rank                The rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items nearest to value and greater by relative rank with a count limit.
+     *
+     * @param value               The value to base the items to remove on.
+     * @param rank                The rank.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByValueRelativeRankRange(Object value, int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items nearest to value and greater by relative rank with a count limit.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param value               The value to base the items to remove on.
+     * @param rank                The rank.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Remove item identified by index and returns removed data.
+     *
+     * @param index               The index to remove the item from.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByIndex(int index, ReturnType returnResultsOfType);
 
+    /**
+     * Remove item identified by index and returns removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param index               The index to remove the item from.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByIndex(WritePolicy writePolicy, int index, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items starting at specified index to the end of list and returns removed data.
+     *
+     * @param index               The start index to remove the item from.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByIndexRange(int index, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items starting at specified index to the end of list and returns removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param index               The start index to remove the item from.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByIndexRange(WritePolicy writePolicy, int index, ReturnType returnResultsOfType);
 
+    /**
+     * Remove "count" items starting at specified index and returns removed data.
+     *
+     * @param index               The start index to remove the item from.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByIndexRange(int index, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Remove "count" items starting at specified index and returns removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param index               The start index to remove the item from.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByIndexRange(WritePolicy writePolicy, int index, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Remove item identified by rank and returns removed data.
+     *
+     * @param rank                The rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByRank(int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Remove item identified by rank and returns removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param rank                The rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByRank(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items starting at specified rank to the last ranked item and returns removed data.
+     *
+     * @param rank                The starting rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByRankRange(int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items starting at specified rank to the last ranked item and returns removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param rank                The starting rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByRankRange(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Remove "count" items starting at specified rank and returns removed data.
+     *
+     * @param rank                The starting rank.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByRankRange(int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Remove "count" items starting at specified rank and returns removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param rank                The starting rank.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     Mono<E> removeByRankRange(WritePolicy writePolicy, int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
+     * the start key and end key will dictate the range of keys to be removed,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to be removed from the list.
+     * <p/>
+     *
+     * @param startKey            Start key of the range to remove.
+     * @param endKey              End key of the range to remove.
+     * @param returnResultsOfType Type to return.
+     * @return The result of the method is a list of the records which have been removed from the database if
+     * returnResults is true, null otherwise.
+     */
     Mono<E> removeByKeyRange(Object startKey, Object endKey, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
+     * the start key and end key will dictate the range of keys to be removed,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to be removed from the list.
+     * <p/>
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param startKey            Start key of the range to remove.
+     * @param endKey              End key of the range to remove.
+     * @param returnResultsOfType Type to return.
+     * @return The result of the method is a list of the records which have been removed from the database if
+     * returnResults is true, null otherwise.
+     */
     Mono<E> removeByKeyRange(WritePolicy writePolicy, Object startKey, Object endKey, ReturnType returnResultsOfType);
 
+    /**
+     * Append a new element at the end of the virtual list.
+     *
+     * @param element The given element to append.
+     * @return The list size.
+     */
     Mono<Long> append(E element);
 
+    /**
+     * Append a new element at the end of the virtual list.
+     *
+     * @param writePolicy An Aerospike write policy to use for the operate() operation.
+     * @param element     The given element to append.
+     * @return The size of the list. If the record is not found, this method returns -1.
+     */
     Mono<Long> append(WritePolicy writePolicy, E element);
 
+    /**
+     * Get an element from the virtual list at a specific index.
+     *
+     * @param index The index to get the item from.
+     * @return The element to get from the virtual list.
+     */
     Mono<E> get(int index);
 
+    /**
+     * Get an element from the virtual list at a specific index.
+     *
+     * @param policy - The policy to use for the operate() operation.
+     * @param index  The index to get the item from.
+     * @return The element to get from the virtual list.
+     */
     Mono<E> get(Policy policy, int index);
 
+    /**
+     * Get the size of the virtual list (number of elements)
+     *
+     * @param policy - The policy to use for the operate() operation.
+     * @return The size of the list. If the record is not found, this method returns -1.
+     */
     Mono<Long> size(Policy policy);
 
+    /**
+     * Remove all the items in the virtual list.
+     */
     Mono<Void> clear();
 }

--- a/src/main/java/com/aerospike/mapper/tools/virtuallist/IVirtualList.java
+++ b/src/main/java/com/aerospike/mapper/tools/virtuallist/IVirtualList.java
@@ -7,115 +7,607 @@ import java.util.List;
 
 public interface IVirtualList<E> {
 
+    /**
+     * Get items from the list matching the specified value.
+     *
+     * @param value               The value to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given value.
+     */
     List<E> getByValue(Object value, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified value.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param value               The value to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given value.
+     */
     List<E> getByValue(WritePolicy writePolicy, Object value, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
+     * the start value and end value will dictate the range of values to get,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
+     * <p/>
+     *
+     * @param startValue          Start value of the range to get.
+     * @param endValue            End value of the range to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given value range.
+     */
     List<E> getByValueRange(Object startValue, Object endValue, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
+     * the start value and end value will dictate the range of values to get,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
+     * <p/>
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param startValue          Start value of the range to get.
+     * @param endValue            End value of the range to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given value range.
+     */
     List<E> getByValueRange(WritePolicy writePolicy, Object startValue, Object endValue, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified list of values.
+     *
+     * @param values              The list of values to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given list of values.
+     */
     List<E> getByValueList(List<Object> values, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified list of values.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param values              The list of values to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given list of values.
+     */
     List<E> getByValueList(WritePolicy writePolicy, List<Object> values, ReturnType returnResultsOfType);
 
+    /**
+     * Get items nearest to value and greater by relative rank.
+     *
+     * @param value               The value to base the relative rank range calculation on.
+     * @param rank                The relative rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of records that matches the given value and rank.
+     */
     List<E> getByValueRelativeRankRange(Object value, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Get items nearest to value and greater by relative rank.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param value               The value to base the relative rank range calculation on.
+     * @param rank                The relative rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of records that matches the given value and rank.
+     */
     List<E> getByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Get items nearest to value and greater by relative rank with a count limit.
+     *
+     * @param value               The value to base the relative rank range calculation on.
+     * @param rank                The relative rank.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of records that matches the given value, rank and count.
+     */
     List<E> getByValueRelativeRankRange(Object value, int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Get items nearest to value and greater by relative rank with a count limit.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param value               The value to base the relative rank range calculation on.
+     * @param rank                The relative rank.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of records that matches the given value, rank and count.
+     */
     List<E> getByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Get items starting at specified index to the end of virtual list.
+     *
+     * @param index               The start index to get items from to the end of the virtual list.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given index.
+     */
     List<E> getByIndexRange(int index, ReturnType returnResultsOfType);
 
+    /**
+     * Get items starting at specified index to the end of virtual list.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param index               The start index to get items from to the end of the virtual list.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given index.
+     */
     List<E> getByIndexRange(WritePolicy writePolicy, int index, ReturnType returnResultsOfType);
 
+    /**
+     * Get "count" items starting at specified index.
+     *
+     * @param index               The start index to get the "count" items from.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given index and count.
+     */
     List<E> getByIndexRange(int index, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Get "count" items starting at specified index.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param index               The start index to get the "count" items from.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given index and count.
+     */
     List<E> getByIndexRange(WritePolicy writePolicy, int index, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Get items identified by rank.
+     *
+     * @param rank                The rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given rank.
+     */
     List<E> getByRank(int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Get items identified by rank.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param rank                The rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given rank.
+     */
     List<E> getByRank(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Get items starting at specified rank to the last ranked item.
+     *
+     * @param rank                The starting rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given rank.
+     */
     List<E> getByRankRange(int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Get items starting at specified rank to the last ranked item.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param rank                The starting rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given rank.
+     */
     List<E> getByRankRange(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Get "count" items starting at specified rank to the last ranked item.
+     *
+     * @param rank                The starting rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given rank and count.
+     */
     List<E> getByRankRange(int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Get "count" items starting at specified rank to the last ranked item.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param rank                The starting rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given rank and count.
+     */
     List<E> getByRankRange(WritePolicy writePolicy, int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
+     * It will get the matching key.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, it will get the matching value.
+     * <p/>
+     *
+     * @param key                 Key to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given key range.
+     */
     List<E> getByKey(Object key, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
+     * It will get the matching key.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, it will get the matching value.
+     * <p/>
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param key                 Key to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given key range.
+     */
     List<E> getByKey(WritePolicy writePolicy, Object key, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified key range. If the list is mapped to a MAP in Aerospike,
+     * the start key and end key will dictate the range of keys to get,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
+     * <p/>
+     *
+     * @param startKey            Start key of the range to get.
+     * @param endKey              End key of the range to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given key range.
+     */
     List<E> getByKeyRange(Object startKey, Object endKey, ReturnType returnResultsOfType);
 
+    /**
+     * Get items from the list matching the specified key range. If the list is mapped to a MAP in Aerospike,
+     * the start key and end key will dictate the range of keys to get,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
+     * <p/>
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param startKey            Start key of the range to get.
+     * @param endKey              End key of the range to get.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which match the given key range.
+     */
     List<E> getByKeyRange(WritePolicy writePolicy, Object startKey, Object endKey, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
+     * the key will dictate the map key to be removed.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the given key will use as the value to remove from the list.
+     * <p/>
+     *
+     * @param key                 Key to remove.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByKey(Object key, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
+     * the key will dictate the map key to be removed.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the given key will use as the value to remove from the list.
+     * <p/>
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param key                 Key to remove.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByKey(WritePolicy writePolicy, Object key, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items identified by value and returns the removed data.
+     *
+     * @param value               The value to base the items to remove on.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByValue(Object value, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items identified by value and returns the removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param value               The value to base the items to remove on.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByValue(WritePolicy writePolicy, Object value, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items identified by list of values and returns the removed data.
+     *
+     * @param values              The list of values to base the items to remove on.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByValueList(List<Object> values, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items identified by list of values and returns the removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param values              The list of values to base the items to remove on.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByValueList(WritePolicy writePolicy, List<Object> values, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
+     * the start value and end value will dictate the range of values to be removed,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to removed from the list.
+     * <p/>
+     *
+     * @param startValue          Start value of the range to remove.
+     * @param endValue            End value of the range to remove.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByValueRange(Object startValue, Object endValue, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
+     * the start value and end value will dictate the range of values to be removed,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to be removed from the list.
+     * <p/>
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param startValue          Start value of the range to remove.
+     * @param endValue            End value of the range to remove.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByValueRange(WritePolicy writePolicy, Object startValue, Object endValue, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items nearest to value and greater by relative rank.
+     *
+     * @param value               The value to base the items to remove on.
+     * @param rank                The rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByValueRelativeRankRange(Object value, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items nearest to value and greater by relative rank.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param value               The value to base the items to remove on.
+     * @param rank                The rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items nearest to value and greater by relative rank with a count limit.
+     *
+     * @param value               The value to base the items to remove on.
+     * @param rank                The rank.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByValueRelativeRankRange(Object value, int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items nearest to value and greater by relative rank with a count limit.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param value               The value to base the items to remove on.
+     * @param rank                The rank.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Remove item identified by index and returns removed data.
+     *
+     * @param index               The index to remove the item from.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByIndex(int index, ReturnType returnResultsOfType);
 
+    /**
+     * Remove item identified by index and returns removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param index               The index to remove the item from.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByIndex(WritePolicy writePolicy, int index, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items starting at specified index to the end of list and returns removed data.
+     *
+     * @param index               The start index to remove the item from.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByIndexRange(int index, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items starting at specified index to the end of list and returns removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param index               The start index to remove the item from.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByIndexRange(WritePolicy writePolicy, int index, ReturnType returnResultsOfType);
 
+    /**
+     * Remove "count" items starting at specified index and returns removed data.
+     *
+     * @param index               The start index to remove the item from.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByIndexRange(int index, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Remove "count" items starting at specified index and returns removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param index               The start index to remove the item from.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByIndexRange(WritePolicy writePolicy, int index, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Remove item identified by rank and returns removed data.
+     *
+     * @param rank                The rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByRank(int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Remove item identified by rank and returns removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param rank                The rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByRank(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items starting at specified rank to the last ranked item and returns removed data.
+     *
+     * @param rank                The starting rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByRankRange(int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items starting at specified rank to the last ranked item and returns removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param rank                The starting rank.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByRankRange(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType);
 
+    /**
+     * Remove "count" items starting at specified rank and returns removed data.
+     *
+     * @param rank                The starting rank.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByRankRange(int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Remove "count" items starting at specified rank and returns removed data.
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param rank                The starting rank.
+     * @param count               The count limit.
+     * @param returnResultsOfType Type to return.
+     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
+     */
     List<E> removeByRankRange(WritePolicy writePolicy, int rank, int count, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
+     * the start key and end key will dictate the range of keys to be removed,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to be removed from the list.
+     * <p/>
+     *
+     * @param startKey            Start key of the range to remove.
+     * @param endKey              End key of the range to remove.
+     * @param returnResultsOfType Type to return.
+     * @return The result of the method is a list of the records which have been removed from the database if
+     * returnResults is true, null otherwise.
+     */
     List<E> removeByKeyRange(Object startKey, Object endKey, ReturnType returnResultsOfType);
 
+    /**
+     * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
+     * the start key and end key will dictate the range of keys to be removed,
+     * inclusive of the start, exclusive of the end.
+     * <p/>
+     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to be removed from the list.
+     * <p/>
+     *
+     * @param writePolicy         An Aerospike write policy to use for the operate() operation.
+     * @param startKey            Start key of the range to remove.
+     * @param endKey              End key of the range to remove.
+     * @param returnResultsOfType Type to return.
+     * @return The result of the method is a list of the records which have been removed from the database if
+     * returnResults is true, null otherwise.
+     */
     List<E> removeByKeyRange(WritePolicy writePolicy, Object startKey, Object endKey, ReturnType returnResultsOfType);
 
+    /**
+     * Append a new element at the end of the virtual list.
+     *
+     * @param element The given element to append.
+     * @return The list size.
+     */
     long append(E element);
 
+    /**
+     * Append a new element at the end of the virtual list.
+     *
+     * @param writePolicy An Aerospike write policy to use for the operate() operation.
+     * @param element     The given element to append.
+     * @return The size of the list. If the record is not found, this method returns -1.
+     */
     long append(WritePolicy writePolicy, E element);
 
+    /**
+     * Get an element from the virtual list at a specific index.
+     *
+     * @param index The index to get the item from.
+     * @return The element to get from the virtual list.
+     */
     E get(int index);
 
+    /**
+     * Get an element from the virtual list at a specific index.
+     *
+     * @param policy - The policy to use for the operate() operation.
+     * @param index  The index to get the item from.
+     * @return The element to get from the virtual list.
+     */
     E get(Policy policy, int index);
 
+    /**
+     * Get the size of the virtual list (number of elements)
+     *
+     * @param policy - The policy to use for the operate() operation.
+     * @return The size of the list. If the record is not found, this method returns -1.
+     */
     long size(Policy policy);
 
+    /**
+     * Remove all the items in the virtual list.
+     */
     void clear();
 }

--- a/src/main/java/com/aerospike/mapper/tools/virtuallist/MultiOperation.java
+++ b/src/main/java/com/aerospike/mapper/tools/virtuallist/MultiOperation.java
@@ -205,6 +205,7 @@ public class MultiOperation<E> {
 
     /**
      * Finish the multi operation and process it.
+     *
      * @return The multi operation result.
      */
     public Object end() {
@@ -213,9 +214,11 @@ public class MultiOperation<E> {
 
     /**
      * Finish the multi operation and process it.
+     *
      * @param resultType The return type for the result.
      * @return The multi operation result with the given result type.
      */
+    @SuppressWarnings("unchecked")
     public <T> T end(Class<T> resultType) {
         if (interactions.isEmpty()) {
             return null;
@@ -266,6 +269,7 @@ public class MultiOperation<E> {
                 Collection<T> collection = (Collection<T>)result;
                 object = collection.isEmpty() ? null : collection.iterator().next();
             }
+            assert object != null;
             mapper.getMappingConverter().resolveDependencies(ClassCache.getInstance().loadClass(object.getClass(), mapper));
         }
         return result;

--- a/src/main/java/com/aerospike/mapper/tools/virtuallist/ReactiveMultiOperation.java
+++ b/src/main/java/com/aerospike/mapper/tools/virtuallist/ReactiveMultiOperation.java
@@ -195,6 +195,7 @@ public class ReactiveMultiOperation<E> {
 
     /**
      * Finish the multi operation and process it.
+     *
      * @return The multi operation result.
      */
     public <T> Mono<T> end() {
@@ -203,9 +204,11 @@ public class ReactiveMultiOperation<E> {
 
     /**
      * Finish the multi operation and process it.
+     *
      * @param resultType The return type for the result.
      * @return The multi operation result with the given result type.
      */
+    @SuppressWarnings("unchecked")
     public <T> Mono<T> end(Class<T> resultType) {
         if (this.interactions.isEmpty()) {
             return null;
@@ -256,6 +259,7 @@ public class ReactiveMultiOperation<E> {
                             Collection<T> collection = (Collection<T>) result;
                             object = collection.isEmpty() ? null : collection.iterator().next();
                         }
+                        assert object != null;
                         reactiveAeroMapper.getMappingConverter().resolveDependencies(ClassCache.getInstance().loadClass(object.getClass(), reactiveAeroMapper));
                     }
                     return result;

--- a/src/main/java/com/aerospike/mapper/tools/virtuallist/ReactiveVirtualList.java
+++ b/src/main/java/com/aerospike/mapper/tools/virtuallist/ReactiveVirtualList.java
@@ -47,23 +47,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
         return new ReactiveMultiOperation<>(writePolicy, binName, listMapper, key, virtualListInteractors, reactiveAeroMapper);
     }
 
-    /**
-     * Get items from the list matching the specified value.
-     * @param value The value to get.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given value.
-     */
+    @Override
     public Mono<E> getByValue(Object value, ReturnType returnResultsOfType) {
         return this.getByValue(null, value, returnResultsOfType);
     }
 
-    /**
-     * Get items from the list matching the specified value.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param value The value to get.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given value.
-     */
+    @Override
     public Mono<E> getByValue(WritePolicy writePolicy, Object value, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -77,35 +66,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Get items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
-     * the start value and end value will dictate the range of values to get,
-     * inclusive of the start, exclusive of the end.
-     * <p/>
-     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
-     * <p/>
-     * @param startValue Start value of the range to get.
-     * @param endValue End value of the range to get.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given value range.
-     */
+    @Override
     public Mono<E> getByValueRange(Object startValue, Object endValue, ReturnType returnResultsOfType) {
         return this.getByValueRange(null, startValue, endValue, returnResultsOfType);
     }
 
-    /**
-     * Get items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
-     * the start value and end value will dictate the range of values to get,
-     * inclusive of the start, exclusive of the end.
-     * <p/>
-     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
-     * <p/>
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param startValue Start value of the range to get.
-     * @param endValue End value of the range to get.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given value range.
-     */
+    @Override
     public Mono<E> getByValueRange(WritePolicy writePolicy, Object startValue, Object endValue, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -119,23 +85,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Get items from the list matching the specified list of values.
-     * @param values The list of values to get.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given list of values.
-     */
+    @Override
     public Mono<E> getByValueList(List<Object> values, ReturnType returnResultsOfType) {
         return this.getByValueList(null, values, returnResultsOfType);
     }
 
-    /**
-     * Get items from the list matching the specified list of values.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param values The list of values to get.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given list of values.
-     */
+    @Override
     public Mono<E> getByValueList(WritePolicy writePolicy, List<Object> values, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -149,25 +104,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Get items nearest to value and greater by relative rank.
-     * @param value The value to base the relative rank range calculation on.
-     * @param rank The relative rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of records that matches the given value and rank.
-     */
+    @Override
     public Mono<E> getByValueRelativeRankRange(Object value, int rank, ReturnType returnResultsOfType) {
         return this.getByValueRelativeRankRange(null, value, rank, returnResultsOfType);
     }
 
-    /**
-     * Get items nearest to value and greater by relative rank.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param value The value to base the relative rank range calculation on.
-     * @param rank The relative rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of records that matches the given value and rank.
-     */
+    @Override
     public Mono<E> getByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -181,27 +123,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Get items nearest to value and greater by relative rank with a count limit.
-     * @param value The value to base the relative rank range calculation on.
-     * @param rank The relative rank.
-     * @param count The count limit.
-     * @param returnResultsOfType Type to return.
-     * @return A list of records that matches the given value, rank and count.
-     */
+    @Override
     public Mono<E> getByValueRelativeRankRange(Object value, int rank, int count, ReturnType returnResultsOfType) {
         return this.getByValueRelativeRankRange(null, value, rank, count, returnResultsOfType);
     }
 
-    /**
-     * Get items nearest to value and greater by relative rank with a count limit.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param value The value to base the relative rank range calculation on.
-     * @param rank The relative rank.
-     * @param count The count limit.
-     * @param returnResultsOfType Type to return.
-     * @return A list of records that matches the given value, rank and count.
-     */
+    @Override
     public Mono<E> getByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, int count, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -215,23 +142,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Get items starting at specified index to the end of virtual list.
-     * @param index The start index to get items from to the end of the virtual list.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given index.
-     */
+    @Override
     public Mono<E> getByIndexRange(int index, ReturnType returnResultsOfType) {
         return this.getByIndexRange(null, index, returnResultsOfType);
     }
 
-    /**
-     * Get items starting at specified index to the end of virtual list.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param index The start index to get items from to the end of the virtual list.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given index.
-     */
+    @Override
     public Mono<E> getByIndexRange(WritePolicy writePolicy, int index, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -245,23 +161,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Get "count" items starting at specified index.
-     * @param index The start index to get the "count" items from.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given index and count.
-     */
+    @Override
     public Mono<E> getByIndexRange(int index, int count, ReturnType returnResultsOfType) {
         return this.getByIndexRange(null, index, count, returnResultsOfType);
     }
 
-    /**
-     * Get "count" items starting at specified index.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param index The start index to get the "count" items from.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given index and count.
-     */
+    @Override
     public Mono<E> getByIndexRange(WritePolicy writePolicy, int index, int count, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -275,23 +180,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Get items identified by rank.
-     * @param rank The rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given rank.
-     */
+    @Override
     public Mono<E> getByRank(int rank, ReturnType returnResultsOfType) {
         return this.getByRank(null, rank, returnResultsOfType);
     }
 
-    /**
-     * Get items identified by rank.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param rank The rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given rank.
-     */
+    @Override
     public Mono<E> getByRank(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -305,23 +199,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Get items starting at specified rank to the last ranked item.
-     * @param rank The starting rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given rank.
-     */
+    @Override
     public Mono<E> getByRankRange(int rank, ReturnType returnResultsOfType) {
         return this.getByRankRange(null, rank, returnResultsOfType);
     }
 
-    /**
-     * Get items starting at specified rank to the last ranked item.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param rank The starting rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given rank.
-     */
+    @Override
     public Mono<E> getByRankRange(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -335,23 +218,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Get "count" items starting at specified rank to the last ranked item.
-     * @param rank The starting rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given rank and count.
-     */
+    @Override
     public Mono<E> getByRankRange(int rank, int count, ReturnType returnResultsOfType) {
         return this.getByRankRange(null, rank, count, returnResultsOfType);
     }
 
-    /**
-     * Get "count" items starting at specified rank to the last ranked item.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param rank The starting rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given rank and count.
-     */
+    @Override
     public Mono<E> getByRankRange(WritePolicy writePolicy, int rank, int count, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -365,31 +237,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Get items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
-     * It will get the matching key.
-     * <p/>
-     * If the list is mapped to a LIST in Aerospike however, it will get the matching value.
-     * <p/>
-     * @param key Key to get.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given key range.
-     */
+    @Override
     public Mono<E> getByKey(Object key, ReturnType returnResultsOfType) {
         return getByKey(null, key, returnResultsOfType);
     }
 
-    /**
-     * Get items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
-     * It will get the matching key.
-     * <p/>
-     * If the list is mapped to a LIST in Aerospike however, it will get the matching value.
-     * <p/>
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param key Key to get.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given key range.
-     */
+    @Override
     public Mono<E> getByKey(WritePolicy writePolicy, Object key, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -403,35 +256,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Get items from the list matching the specified key range. If the list is mapped to a MAP in Aerospike,
-     * the start key and end key will dictate the range of keys to get,
-     * inclusive of the start, exclusive of the end.
-     * <p/>
-     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
-     * <p/>
-     * @param startKey Start key of the range to get.
-     * @param endKey End key of the range to get.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given key range.
-     */
+    @Override
     public Mono<E> getByKeyRange(Object startKey, Object endKey, ReturnType returnResultsOfType) {
         return getByKeyRange(null, startKey, endKey, returnResultsOfType);
     }
 
-    /**
-     * Get items from the list matching the specified key range. If the list is mapped to a MAP in Aerospike,
-     * the start key and end key will dictate the range of keys to get,
-     * inclusive of the start, exclusive of the end.
-     * <p/>
-     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
-     * <p/>
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param startKey Start key of the range to get.
-     * @param endKey End key of the range to get.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which match the given key range.
-     */
+    @Override
     public Mono<E> getByKeyRange(WritePolicy writePolicy, Object startKey, Object endKey, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -445,31 +275,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
-     * the key will dictate the map key to be removed.
-     * <p/>
-     * If the list is mapped to a LIST in Aerospike however, the given key will use as the value to remove from the list.
-     * <p/>
-     * @param key Key to remove.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByKey(Object key, ReturnType returnResultsOfType) {
         return removeByKey(null, key, returnResultsOfType);
     }
 
-    /**
-     * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
-     * the key will dictate the map key to be removed.
-     * <p/>
-     * If the list is mapped to a LIST in Aerospike however, the given key will use as the value to remove from the list.
-     * <p/>
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param key Key to remove.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByKey(WritePolicy writePolicy, Object key, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -483,23 +294,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Remove items identified by value and returns the removed data.
-     * @param value The value to base the items to remove on.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByValue(Object value, ReturnType returnResultsOfType) {
         return this.removeByValue(null, value, returnResultsOfType);
     }
 
-    /**
-     * Remove items identified by value and returns the removed data.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param value The value to base the items to remove on.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByValue(WritePolicy writePolicy, Object value, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -513,23 +313,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Remove items identified by list of values and returns the removed data.
-     * @param values The list of values to base the items to remove on.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByValueList(List<Object> values, ReturnType returnResultsOfType) {
         return this.removeByValueList(null, values, returnResultsOfType);
     }
 
-    /**
-     * Remove items identified by list of values and returns the removed data.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param values The list of values to base the items to remove on.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByValueList(WritePolicy writePolicy, List<Object> values, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -543,35 +332,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Remove items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
-     * the start value and end value will dictate the range of values to be removed,
-     * inclusive of the start, exclusive of the end.
-     * <p/>
-     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to removed from the list.
-     * <p/>
-     * @param startValue Start value of the range to remove.
-     * @param endValue End value of the range to remove.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByValueRange(Object startValue, Object endValue, ReturnType returnResultsOfType) {
         return this.removeByValueRange(null, startValue, endValue, returnResultsOfType);
     }
 
-    /**
-     * Remove items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
-     * the start value and end value will dictate the range of values to be removed,
-     * inclusive of the start, exclusive of the end.
-     * <p/>
-     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to be removed from the list.
-     * <p/>
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param startValue Start value of the range to remove.
-     * @param endValue End value of the range to remove.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByValueRange(WritePolicy writePolicy, Object startValue, Object endValue, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -585,25 +351,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Remove items nearest to value and greater by relative rank.
-     * @param value The value to base the items to remove on.
-     * @param rank The rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByValueRelativeRankRange(Object value, int rank, ReturnType returnResultsOfType) {
         return this.removeByValueRelativeRankRange(null, value, rank, returnResultsOfType);
     }
 
-    /**
-     * Remove items nearest to value and greater by relative rank.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param value The value to base the items to remove on.
-     * @param rank The rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -617,27 +370,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Remove items nearest to value and greater by relative rank with a count limit.
-     * @param value The value to base the items to remove on.
-     * @param rank The rank.
-     * @param count The count limit.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByValueRelativeRankRange(Object value, int rank, int count, ReturnType returnResultsOfType) {
         return this.removeByValueRelativeRankRange(null, value, rank, count, returnResultsOfType);
     }
 
-    /**
-     * Remove items nearest to value and greater by relative rank with a count limit.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param value The value to base the items to remove on.
-     * @param rank The rank.
-     * @param count The count limit.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, int count, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -651,23 +389,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Remove item identified by index and returns removed data.
-     * @param index The index to remove the item from.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByIndex(int index, ReturnType returnResultsOfType) {
         return this.removeByIndex(null, index, returnResultsOfType);
     }
 
-    /**
-     * Remove item identified by index and returns removed data.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param index The index to remove the item from.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByIndex(WritePolicy writePolicy, int index, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -681,23 +408,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Remove items starting at specified index to the end of list and returns removed data.
-     * @param index The start index to remove the item from.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByIndexRange(int index, ReturnType returnResultsOfType) {
         return this.removeByIndexRange(null, index, returnResultsOfType);
     }
 
-    /**
-     * Remove items starting at specified index to the end of list and returns removed data.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param index The start index to remove the item from.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByIndexRange(WritePolicy writePolicy, int index, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -711,25 +427,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Remove "count" items starting at specified index and returns removed data.
-     * @param index The start index to remove the item from.
-     * @param count The count limit.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByIndexRange(int index, int count, ReturnType returnResultsOfType) {
         return this.removeByIndexRange(null, index, count, returnResultsOfType);
     }
 
-    /**
-     * Remove "count" items starting at specified index and returns removed data.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param index The start index to remove the item from.
-     * @param count The count limit.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByIndexRange(WritePolicy writePolicy, int index, int count, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -743,23 +446,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Remove item identified by rank and returns removed data.
-     * @param rank The rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByRank(int rank, ReturnType returnResultsOfType) {
         return this.removeByRank(null, rank, returnResultsOfType);
     }
 
-    /**
-     * Remove item identified by rank and returns removed data.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param rank The rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByRank(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -773,23 +465,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Remove items starting at specified rank to the last ranked item and returns removed data.
-     * @param rank The starting rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByRankRange(int rank, ReturnType returnResultsOfType) {
         return this.removeByRankRange(null, rank, returnResultsOfType);
     }
 
-    /**
-     * Remove items starting at specified rank to the last ranked item and returns removed data.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param rank The starting rank.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByRankRange(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -803,25 +484,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Remove "count" items starting at specified rank and returns removed data.
-     * @param rank The starting rank.
-     * @param count The count limit.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByRankRange(int rank, int count, ReturnType returnResultsOfType) {
         return this.removeByRankRange(null, rank, count, returnResultsOfType);
     }
 
-    /**
-     * Remove "count" items starting at specified rank and returns removed data.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param rank The starting rank.
-     * @param count The count limit.
-     * @param returnResultsOfType Type to return.
-     * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByRankRange(WritePolicy writePolicy, int rank, int count, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -835,37 +503,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
-     * the start key and end key will dictate the range of keys to be removed,
-     * inclusive of the start, exclusive of the end.
-     * <p/>
-     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to be removed from the list.
-     * <p/>
-     * @param startKey Start key of the range to remove.
-     * @param endKey End key of the range to remove.
-     * @param returnResultsOfType Type to return.
-     * @return The result of the method is a list of the records which have been removed from the database if
-     * returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByKeyRange(Object startKey, Object endKey, ReturnType returnResultsOfType) {
         return this.removeByKeyRange(null, startKey, endKey, returnResultsOfType);
     }
 
-    /**
-     * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
-     * the start key and end key will dictate the range of keys to be removed,
-     * inclusive of the start, exclusive of the end.
-     * <p/>
-     * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to be removed from the list.
-     * <p/>
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param startKey Start key of the range to remove.
-     * @param endKey End key of the range to remove.
-     * @param returnResultsOfType Type to return.
-     * @return The result of the method is a list of the records which have been removed from the database if
-     * returnResults is true, null otherwise.
-     */
+    @Override
     public Mono<E> removeByKeyRange(WritePolicy writePolicy, Object startKey, Object endKey, ReturnType returnResultsOfType) {
         if (writePolicy == null) {
             writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -879,21 +522,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Append a new element at the end of the virtual list.
-     * @param element The given element to append.
-     * @return The list size.
-     */
+    @Override
     public Mono<Long> append(E element) {
         return this.append(null, element);
     }
 
-    /**
-     * Append a new element at the end of the virtual list.
-     * @param writePolicy An Aerospike write policy to use for the operate() operation.
-     * @param element The given element to append.
-     * @return The size of the list. If the record is not found, this method returns -1.
-     */
+    @Override
     public Mono<Long> append(WritePolicy writePolicy, E element) {
         Object result = listMapper.toAerospikeInstanceFormat(element);
         if (writePolicy == null) {
@@ -905,21 +539,12 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> keyRecord == null ? -1L : keyRecord.record.getLong(binName));
     }
 
-    /**
-     * Get an element from the virtual list at a specific index.
-     * @param index The index to get the item from.
-     * @return The element to get from the virtual list.
-     */
+    @Override
     public Mono<E> get(int index) {
         return get(null, index);
     }
 
-    /**
-     * Get an element from the virtual list at a specific index.
-     * @param policy - The policy to use for the operate() operation.
-     * @param index The index to get the item from.
-     * @return The element to get from the virtual list.
-     */
+    @Override
     public Mono<E> get(Policy policy, int index) {
         Interactor interactor = virtualListInteractors.getByIndexInteractor(index);
         return reactiveAeroMapper.getReactorClient()
@@ -927,11 +552,7 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> getResultsWithDependencies(keyRecord, interactor));
     }
 
-    /**
-     * Get the size of the virtual list (number of elements)
-     * @param policy - The policy to use for the operate() operation.
-     * @return The size of the list. If the record is not found, this method returns -1.
-     */
+    @Override
     public Mono<Long> size(Policy policy) {
         Interactor interactor = virtualListInteractors.getSizeInteractor();
         return reactiveAeroMapper.getReactorClient()
@@ -939,9 +560,7 @@ public class ReactiveVirtualList<E> extends BaseVirtualList<E> implements IReact
                 .map(keyRecord -> keyRecord == null ? -1L : keyRecord.record.getLong(binName));
     }
 
-    /**
-     * Remove all the items in the virtual list.
-     */
+    @Override
     public Mono<Void> clear() {
         Interactor interactor = virtualListInteractors.getClearInteractor();
         return reactiveAeroMapper.getReactorClient()

--- a/src/main/java/com/aerospike/mapper/tools/virtuallist/VirtualList.java
+++ b/src/main/java/com/aerospike/mapper/tools/virtuallist/VirtualList.java
@@ -46,23 +46,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return new MultiOperation<>(writePolicy, binName, listMapper, key, virtualListInteractors, mapper);
 	}
 
-	/**
-	 * Get items from the list matching the specified value.
-	 * @param value The value to get.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given value.
-	 */
+	@Override
 	public List<E> getByValue(Object value, ReturnType returnResultsOfType) {
 		return this.getByValue(null, value, returnResultsOfType);
 	}
 
-	/**
-	 * Get items from the list matching the specified value.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param value The value to get.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given value.
-	 */
+	@Override
 	public List<E> getByValue(WritePolicy writePolicy, Object value, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -74,35 +63,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Get items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
-	 * the start value and end value will dictate the range of values to get,
-	 * inclusive of the start, exclusive of the end.
-	 * <p/>
-	 * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
-	 * <p/>
-	 * @param startValue Start value of the range to get.
-	 * @param endValue End value of the range to get.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given value range.
-	 */
+	@Override
 	public List<E> getByValueRange(Object startValue, Object endValue, ReturnType returnResultsOfType) {
 		return this.getByValueRange(null, startValue, endValue, returnResultsOfType);
 	}
 
-	/**
-	 * Get items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
-	 * the start value and end value will dictate the range of values to get,
-	 * inclusive of the start, exclusive of the end.
-	 * <p/>
-	 * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
-	 * <p/>
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param startValue Start value of the range to get.
-	 * @param endValue End value of the range to get.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given value range.
-	 */
+	@Override
 	public List<E> getByValueRange(WritePolicy writePolicy, Object startValue, Object endValue, ReturnType returnResultsOfType) {
     	if (writePolicy == null) {
         	writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -114,23 +80,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Get items from the list matching the specified list of values.
-	 * @param values The list of values to get.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given list of values.
-	 */
+	@Override
 	public List<E> getByValueList(List<Object> values, ReturnType returnResultsOfType) {
 		return this.getByValueList(null, values, returnResultsOfType);
 	}
 
-	/**
-	 * Get items from the list matching the specified list of values.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param values The list of values to get.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given list of values.
-	 */
+	@Override
 	public List<E> getByValueList(WritePolicy writePolicy, List<Object> values, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -142,25 +97,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Get items nearest to value and greater by relative rank.
-	 * @param value The value to base the relative rank range calculation on.
-	 * @param rank The relative rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of records that matches the given value and rank.
-	 */
+	@Override
 	public List<E> getByValueRelativeRankRange(Object value, int rank, ReturnType returnResultsOfType) {
 		return this.getByValueRelativeRankRange(null, value, rank, returnResultsOfType);
 	}
 
-	/**
-	 * Get items nearest to value and greater by relative rank.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param value The value to base the relative rank range calculation on.
-	 * @param rank The relative rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of records that matches the given value and rank.
-	 */
+	@Override
 	public List<E> getByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -172,27 +114,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Get items nearest to value and greater by relative rank with a count limit.
-	 * @param value The value to base the relative rank range calculation on.
-	 * @param rank The relative rank.
-	 * @param count The count limit.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of records that matches the given value, rank and count.
-	 */
+	@Override
 	public List<E> getByValueRelativeRankRange(Object value, int rank, int count, ReturnType returnResultsOfType) {
 		return this.getByValueRelativeRankRange(null, value, rank, count, returnResultsOfType);
 	}
 
-	/**
-	 * Get items nearest to value and greater by relative rank with a count limit.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param value The value to base the relative rank range calculation on.
-	 * @param rank The relative rank.
-	 * @param count The count limit.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of records that matches the given value, rank and count.
-	 */
+	@Override
 	public List<E> getByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, int count, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -204,23 +131,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Get items starting at specified index to the end of virtual list.
-	 * @param index The start index to get items from to the end of the virtual list.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given index.
-	 */
+	@Override
 	public List<E> getByIndexRange(int index, ReturnType returnResultsOfType) {
 		return this.getByIndexRange(null, index, returnResultsOfType);
 	}
 
-	/**
-	 * Get items starting at specified index to the end of virtual list.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param index The start index to get items from to the end of the virtual list.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given index.
-	 */
+	@Override
 	public List<E> getByIndexRange(WritePolicy writePolicy, int index, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -232,23 +148,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Get "count" items starting at specified index.
-	 * @param index The start index to get the "count" items from.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given index and count.
-	 */
+	@Override
 	public List<E> getByIndexRange(int index, int count, ReturnType returnResultsOfType) {
 		return this.getByIndexRange(null, index, count, returnResultsOfType);
 	}
 
-	/**
-	 * Get "count" items starting at specified index.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param index The start index to get the "count" items from.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given index and count.
-	 */
+	@Override
 	public List<E> getByIndexRange(WritePolicy writePolicy, int index, int count, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -260,23 +165,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Get items identified by rank.
-	 * @param rank The rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given rank.
-	 */
+	@Override
 	public List<E> getByRank(int rank, ReturnType returnResultsOfType) {
 		return this.getByRank(null, rank, returnResultsOfType);
 	}
 
-	/**
-	 * Get items identified by rank.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param rank The rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given rank.
-	 */
+	@Override
 	public List<E> getByRank(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -288,23 +182,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Get items starting at specified rank to the last ranked item.
-	 * @param rank The starting rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given rank.
-	 */
+	@Override
 	public List<E> getByRankRange(int rank, ReturnType returnResultsOfType) {
 		return this.getByRankRange(null, rank, returnResultsOfType);
 	}
 
-	/**
-	 * Get items starting at specified rank to the last ranked item.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param rank The starting rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given rank.
-	 */
+	@Override
 	public List<E> getByRankRange(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -316,23 +199,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Get "count" items starting at specified rank to the last ranked item.
-	 * @param rank The starting rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given rank and count.
-	 */
+	@Override
 	public List<E> getByRankRange(int rank, int count, ReturnType returnResultsOfType) {
 		return this.getByRankRange(null, rank, count, returnResultsOfType);
 	}
 
-	/**
-	 * Get "count" items starting at specified rank to the last ranked item.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param rank The starting rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given rank and count.
-	 */
+	@Override
 	public List<E> getByRankRange(WritePolicy writePolicy, int rank, int count, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -344,31 +216,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Get items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
-	 * It will get the matching key.
-	 * <p/>
-	 * If the list is mapped to a LIST in Aerospike however, it will get the matching value.
-	 * <p/>
-	 * @param key Key to get.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given key range.
-	 */
+	@Override
 	public List<E> getByKey(Object key, ReturnType returnResultsOfType) {
 		return getByKey(null, key, returnResultsOfType);
 	}
 
-	/**
-	 * Get items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
-	 * It will get the matching key.
-	 * <p/>
-	 * If the list is mapped to a LIST in Aerospike however, it will get the matching value.
-	 * <p/>
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param key Key to get.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given key range.
-	 */
+	@Override
 	public List<E> getByKey(WritePolicy writePolicy, Object key, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -380,35 +233,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Get items from the list matching the specified key range. If the list is mapped to a MAP in Aerospike,
-	 * the start key and end key will dictate the range of keys to get,
-	 * inclusive of the start, exclusive of the end.
-	 * <p/>
-	 * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
-	 * <p/>
-	 * @param startKey Start key of the range to get.
-	 * @param endKey End key of the range to get.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given key range.
-	 */
+	@Override
 	public List<E> getByKeyRange(Object startKey, Object endKey, ReturnType returnResultsOfType) {
 		return getByKeyRange(null, startKey, endKey, returnResultsOfType);
 	}
 
-	/**
-	 * Get items from the list matching the specified key range. If the list is mapped to a MAP in Aerospike,
-	 * the start key and end key will dictate the range of keys to get,
-	 * inclusive of the start, exclusive of the end.
-	 * <p/>
-	 * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to get from the list.
-	 * <p/>
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param startKey Start key of the range to get.
-	 * @param endKey End key of the range to get.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which match the given key range.
-	 */
+	@Override
 	public List<E> getByKeyRange(WritePolicy writePolicy, Object startKey, Object endKey, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -420,31 +250,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
-	 * the key will dictate the map key to be removed.
-	 * <p/>
-	 * If the list is mapped to a LIST in Aerospike however, the given key will use as the value to remove from the list.
-	 * <p/>
-	 * @param key Key to remove.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByKey(Object key, ReturnType returnResultsOfType) {
 		return removeByKey(null, key, returnResultsOfType);
 	}
 
-	/**
-	 * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
-	 * the key will dictate the map key to be removed.
-	 * <p/>
-	 * If the list is mapped to a LIST in Aerospike however, the given key will use as the value to remove from the list.
-	 * <p/>
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param key Key to remove.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByKey(WritePolicy writePolicy, Object key, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -456,23 +267,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Remove items identified by value and returns the removed data.
-	 * @param value The value to base the items to remove on.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByValue(Object value, ReturnType returnResultsOfType) {
 		return this.removeByValue(null, value, returnResultsOfType);
 	}
 
-	/**
-	 * Remove items identified by value and returns the removed data.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param value The value to base the items to remove on.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByValue(WritePolicy writePolicy, Object value, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -484,23 +284,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Remove items identified by list of values and returns the removed data.
-	 * @param values The list of values to base the items to remove on.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByValueList(List<Object> values, ReturnType returnResultsOfType) {
 		return this.removeByValueList(null, values, returnResultsOfType);
 	}
 
-	/**
-	 * Remove items identified by list of values and returns the removed data.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param values The list of values to base the items to remove on.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByValueList(WritePolicy writePolicy, List<Object> values, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -512,35 +301,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Remove items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
-	 * the start value and end value will dictate the range of values to be removed,
-	 * inclusive of the start, exclusive of the end.
-	 * <p/>
-	 * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to removed from the list.
-	 * <p/>
-	 * @param startValue Start value of the range to remove.
-	 * @param endValue End value of the range to remove.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByValueRange(Object startValue, Object endValue, ReturnType returnResultsOfType) {
 		return this.removeByValueRange(null, startValue, endValue, returnResultsOfType);
 	}
 
-	/**
-	 * Remove items from the list matching the specified value. If the list is mapped to a MAP in Aerospike,
-	 * the start value and end value will dictate the range of values to be removed,
-	 * inclusive of the start, exclusive of the end.
-	 * <p/>
-	 * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to be removed from the list.
-	 * <p/>
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param startValue Start value of the range to remove.
-	 * @param endValue End value of the range to remove.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByValueRange(WritePolicy writePolicy, Object startValue, Object endValue, ReturnType returnResultsOfType) {
     	if (writePolicy == null) {
         	writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -552,25 +318,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Remove items nearest to value and greater by relative rank.
-	 * @param value The value to base the items to remove on.
-	 * @param rank The rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByValueRelativeRankRange(Object value, int rank, ReturnType returnResultsOfType) {
 		return this.removeByValueRelativeRankRange(null, value, rank, returnResultsOfType);
 	}
 
-	/**
-	 * Remove items nearest to value and greater by relative rank.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param value The value to base the items to remove on.
-	 * @param rank The rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -582,27 +335,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Remove items nearest to value and greater by relative rank with a count limit.
-	 * @param value The value to base the items to remove on.
-	 * @param rank The rank.
-	 * @param count The count limit.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByValueRelativeRankRange(Object value, int rank, int count, ReturnType returnResultsOfType) {
 		return this.removeByValueRelativeRankRange(null, value, rank, count, returnResultsOfType);
 	}
 
-	/**
-	 * Remove items nearest to value and greater by relative rank with a count limit.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param value The value to base the items to remove on.
-	 * @param rank The rank.
-	 * @param count The count limit.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByValueRelativeRankRange(WritePolicy writePolicy, Object value, int rank, int count, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -614,23 +352,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Remove item identified by index and returns removed data.
-	 * @param index The index to remove the item from.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByIndex(int index, ReturnType returnResultsOfType) {
 		return this.removeByIndex(null, index, returnResultsOfType);
 	}
 
-	/**
-	 * Remove item identified by index and returns removed data.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param index The index to remove the item from.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByIndex(WritePolicy writePolicy, int index, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -642,23 +369,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Remove items starting at specified index to the end of list and returns removed data.
-	 * @param index The start index to remove the item from.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByIndexRange(int index, ReturnType returnResultsOfType) {
 		return this.removeByIndexRange(null, index, returnResultsOfType);
 	}
 
-	/**
-	 * Remove items starting at specified index to the end of list and returns removed data.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param index The start index to remove the item from.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByIndexRange(WritePolicy writePolicy, int index, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -670,25 +386,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Remove "count" items starting at specified index and returns removed data.
-	 * @param index The start index to remove the item from.
-	 * @param count The count limit.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByIndexRange(int index, int count, ReturnType returnResultsOfType) {
 		return this.removeByIndexRange(null, index, count, returnResultsOfType);
 	}
 
-	/**
-	 * Remove "count" items starting at specified index and returns removed data.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param index The start index to remove the item from.
-	 * @param count The count limit.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByIndexRange(WritePolicy writePolicy, int index, int count, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -700,23 +403,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Remove item identified by rank and returns removed data.
-	 * @param rank The rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByRank(int rank, ReturnType returnResultsOfType) {
 		return this.removeByRank(null, rank, returnResultsOfType);
 	}
 
-	/**
-	 * Remove item identified by rank and returns removed data.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param rank The rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByRank(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -728,23 +420,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Remove items starting at specified rank to the last ranked item and returns removed data.
-	 * @param rank The starting rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByRankRange(int rank, ReturnType returnResultsOfType) {
 		return this.removeByRankRange(null, rank, returnResultsOfType);
 	}
 
-	/**
-	 * Remove items starting at specified rank to the last ranked item and returns removed data.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param rank The starting rank.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByRankRange(WritePolicy writePolicy, int rank, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -756,25 +437,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Remove "count" items starting at specified rank and returns removed data.
-	 * @param rank The starting rank.
-	 * @param count The count limit.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByRankRange(int rank, int count, ReturnType returnResultsOfType) {
 		return this.removeByRankRange(null, rank, count, returnResultsOfType);
 	}
 
-	/**
-	 * Remove "count" items starting at specified rank and returns removed data.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param rank The starting rank.
-	 * @param count The count limit.
-	 * @param returnResultsOfType Type to return.
-	 * @return A list of the records which have been removed from the database if returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByRankRange(WritePolicy writePolicy, int rank, int count, ReturnType returnResultsOfType) {
 		if (writePolicy == null) {
 			writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -786,37 +454,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 	
-	/**
-	 * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
-	 * the start key and end key will dictate the range of keys to be removed,
-	 * inclusive of the start, exclusive of the end.
-	 * <p/>
-	 * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to be removed from the list.
-	 * <p/>
-	 * @param startKey Start key of the range to remove.
-	 * @param endKey End key of the range to remove.
-	 * @param returnResultsOfType Type to return.
-	 * @return The result of the method is a list of the records which have been removed from the database if
-	 * returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByKeyRange(Object startKey, Object endKey, ReturnType returnResultsOfType) {
 		return this.removeByKeyRange(null, startKey, endKey, returnResultsOfType);
 	}
 
-	/**
-	 * Remove items from the list matching the specified key. If the list is mapped to a MAP in Aerospike,
-	 * the start key and end key will dictate the range of keys to be removed,
-	 * inclusive of the start, exclusive of the end.
-	 * <p/>
-	 * If the list is mapped to a LIST in Aerospike however, the start and end range represent values to be removed from the list.
-	 * <p/>
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param startKey Start key of the range to remove.
-	 * @param endKey End key of the range to remove.
-	 * @param returnResultsOfType Type to return.
-	 * @return The result of the method is a list of the records which have been removed from the database if
-	 * returnResults is true, null otherwise.
-	 */
+	@Override
 	public List<E> removeByKeyRange(WritePolicy writePolicy, Object startKey, Object endKey, ReturnType returnResultsOfType) {
     	if (writePolicy == null) {
         	writePolicy = new WritePolicy(owningEntry.getWritePolicy());
@@ -828,21 +471,12 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
 		return getResultsAsListWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Append a new element at the end of the virtual list.
-	 * @param element The given element to append.
-	 * @return The list size.
-	 */
+	@Override
 	public long append(E element) {
 		return this.append(null, element);
 	}
 
-	/**
-	 * Append a new element at the end of the virtual list.
-	 * @param writePolicy An Aerospike write policy to use for the operate() operation.
-	 * @param element The given element to append.
-	 * @return The size of the list. If the record is not found, this method returns -1.
-	 */
+	@Override
 	public long append(WritePolicy writePolicy, E element) {
     	Object result = listMapper.toAerospikeInstanceFormat(element);
     	if (writePolicy == null) {
@@ -853,41 +487,26 @@ public class VirtualList<E> extends BaseVirtualList<E> implements IVirtualList<E
     	return record == null ? -1L : record.getLong(binName);
 	}
 
-	/**
-	 * Get an element from the virtual list at a specific index.
-	 * @param index The index to get the item from.
-	 * @return The element to get from the virtual list.
-	 */
+	@Override
 	public E get(int index) {
 		return get(null, index);
 	}
 
-	/**
-	 * Get an element from the virtual list at a specific index.
-	 * @param policy - The policy to use for the operate() operation.
-	 * @param index The index to get the item from.
-	 * @return The element to get from the virtual list.
-	 */
+	@Override
 	public E get(Policy policy, int index) {
     	Interactor interactor = virtualListInteractors.getByIndexInteractor(index);
 		Record record = this.mapper.getClient().operate(getWritePolicy(policy), key, interactor.getOperation());
 		return getResultsWithDependencies(record, interactor);
 	}
 
-	/**
-	 * Get the size of the virtual list (number of elements)
-	 * @param policy - The policy to use for the operate() operation.
-	 * @return The size of the list. If the record is not found, this method returns -1.
-	 */
+	@Override
 	public long size(Policy policy) {
     	Interactor interactor = virtualListInteractors.getSizeInteractor();
 		Record record = this.mapper.getClient().operate(getWritePolicy(policy), key, interactor.getOperation());
 		return record == null ? -1L : record.getLong(binName);
 	}
 
-	/**
-	 * Remove all the items in the virtual list.
-	 */
+	@Override
 	public void clear() {
 		Interactor interactor = virtualListInteractors.getClearInteractor();
 		this.mapper.getClient().operate(null, key, interactor.getOperation());


### PR DESCRIPTION
1. Javadoc standardization.
2. Reorder methods to align with interfaces at the "right order".
3. Add SuppressWarning("unchecked")/assertions at relevant places.