### PR TITLE
Set version to 1.3.0 and bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ The documentation for this project can be found on [javadoc.io](https://www.java
 
 # Compatibility with Aerospike Clients
 
-|`java-object-mapper` Version | Aerospike Client | Aerospike Reactor Client
+| Java Object Mapper Version | Aerospike Client | Aerospike Reactor Client
 | :----------- | :----------- | :-----------
-| 1.2.x | 5.1.x | 5.0.x
+| 1.2.x, 1.3.x | 5.1.x | 5.0.x
 | 1.1.x | 5.0.x | 
 
 # Motivation and a simple example

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.aerospike</groupId>
 	<artifactId>java-object-mapper</artifactId>
-	<version>1.2.3</version>
+	<version>1.3.0</version>
 	<packaging>jar</packaging>
 	
 	<name>Aerospike Object Mapper</name>
@@ -28,12 +28,12 @@
 		<maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
 		<javax.validation-api.version>2.0.1.Final</javax.validation-api.version>
-		<aerospike-client.version>5.1.6</aerospike-client.version>
+		<aerospike-client.version>5.1.7</aerospike-client.version>
 		<aerospike-reactor.version>5.0.7</aerospike-reactor.version>
 		<commons-lang3.version>3.12.0</commons-lang3.version>
-		<jackson-dataformat-yaml.version>2.12.4</jackson-dataformat-yaml.version>
+		<jackson-dataformat-yaml.version>2.12.5</jackson-dataformat-yaml.version>
 		<lombok.version>1.18.20</lombok.version>
-		<reactor-test.version>3.4.8</reactor-test.version>
+		<reactor-test.version>3.4.9</reactor-test.version>
 		<blockhound.version>1.0.6.RELEASE</blockhound.version>
 		<junit-jupiter.version>5.7.2</junit-jupiter.version>
 	</properties>


### PR DESCRIPTION
1. Set version to 1.3.0.
2. Bump dependencies:
aerospike-client from 5.1.6 to 5.1.7.
jackson-dataformat-yaml from 2.12.4 to 2.12.5.
reactor-test from 3.4.8 to 3.4.9.