### PR TITLE
Bump java clients to version 5.1.11 to fix CLIENT-1637 bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
 		<maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
 		<javax.validation-api.version>2.0.1.Final</javax.validation-api.version>
-		<aerospike-client.version>5.1.8</aerospike-client.version>
-		<aerospike-reactor.version>5.1.8</aerospike-reactor.version>
+		<aerospike-client.version>5.1.11</aerospike-client.version>
+		<aerospike-reactor.version>5.1.11</aerospike-reactor.version>
 		<commons-lang3.version>3.12.0</commons-lang3.version>
 		<jackson-dataformat-yaml.version>2.13.0</jackson-dataformat-yaml.version>
 		<lombok.version>1.18.22</lombok.version>


### PR DESCRIPTION
Java client & reactive java client version 5.1.11 fixes CLIENT-1637 issue "Continue processing scans when "partition unavailable" errors occur. "partition unavailable" is not a fatal error for partition scans and the server will continue sending back results for other partitions. Previous clients aborted the scan and put the connection back into the pool which might cause unprocessed results to be sent to a different transaction."