### PR TITLE
Permit unannotated embedded classes

### DIFF
--- a/src/main/java/com/aerospike/mapper/tools/ClassCacheEntry.java
+++ b/src/main/java/com/aerospike/mapper/tools/ClassCacheEntry.java
@@ -1,24 +1,5 @@
 package com.aerospike.mapper.tools;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Parameter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
-
-import javax.validation.constraints.NotNull;
-
-import org.apache.commons.lang3.StringUtils;
-
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Bin;
 import com.aerospike.client.Key;
@@ -30,15 +11,7 @@ import com.aerospike.client.policy.Policy;
 import com.aerospike.client.policy.QueryPolicy;
 import com.aerospike.client.policy.ScanPolicy;
 import com.aerospike.client.policy.WritePolicy;
-import com.aerospike.mapper.annotations.AerospikeBin;
-import com.aerospike.mapper.annotations.AerospikeConstructor;
-import com.aerospike.mapper.annotations.AerospikeExclude;
-import com.aerospike.mapper.annotations.AerospikeGetter;
-import com.aerospike.mapper.annotations.AerospikeKey;
-import com.aerospike.mapper.annotations.AerospikeOrdinal;
-import com.aerospike.mapper.annotations.AerospikeRecord;
-import com.aerospike.mapper.annotations.AerospikeSetter;
-import com.aerospike.mapper.annotations.ParamFrom;
+import com.aerospike.mapper.annotations.*;
 import com.aerospike.mapper.exceptions.NotAnnotatedClass;
 import com.aerospike.mapper.tools.configuration.BinConfig;
 import com.aerospike.mapper.tools.configuration.ClassConfig;
@@ -46,6 +19,16 @@ import com.aerospike.mapper.tools.configuration.KeyConfig;
 import com.aerospike.mapper.tools.utils.ParserUtils;
 import com.aerospike.mapper.tools.utils.TypeUtils;
 import com.aerospike.mapper.tools.utils.TypeUtils.AnnotatedType;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.validation.constraints.NotNull;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.util.*;
 
 public class ClassCacheEntry<T> {
 
@@ -144,7 +127,7 @@ public class ClassCacheEntry<T> {
 
         this.loadFieldsFromClass();
         this.loadPropertiesFromClass();
-        this.superClazz = ClassCache.getInstance().loadClass(this.clazz.getSuperclass(), this.mapper);
+        this.superClazz = ClassCache.getInstance().loadClass(this.clazz.getSuperclass(), this.mapper, !this.mapAll);
         this.binCount = this.values.size() + (superClazz != null ? superClazz.binCount : 0);
         if (this.binCount == 0) {
             throw new AerospikeException(String.format("Class %s has no values defined to be stored in the database",

--- a/src/main/java/com/aerospike/mapper/tools/utils/MapperUtils.java
+++ b/src/main/java/com/aerospike/mapper/tools/utils/MapperUtils.java
@@ -7,6 +7,10 @@ import com.aerospike.mapper.tools.IBaseAeroMapper;
 import org.apache.commons.lang3.StringUtils;
 
 public class MapperUtils {
+
+    private MapperUtils() {
+    }
+
     public static <T> ClassCacheEntry<T> getEntryAndValidateNamespace(Class<T> clazz, IBaseAeroMapper mapper) {
         ClassCacheEntry<T> entry = ClassCache.getInstance().loadClass(clazz, mapper);
         String namespace = null;

--- a/src/test/java/com/aerospike/mapper/EmbeddedClassTest.java
+++ b/src/test/java/com/aerospike/mapper/EmbeddedClassTest.java
@@ -1,0 +1,58 @@
+package com.aerospike.mapper;
+
+import com.aerospike.mapper.annotations.AerospikeEmbed;
+import com.aerospike.mapper.annotations.AerospikeKey;
+import com.aerospike.mapper.annotations.AerospikeRecord;
+import com.aerospike.mapper.tools.AeroMapper;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EmbeddedClassTest extends AeroMapperBaseTest {
+
+    @Test
+    void test() {
+        Embed2 embed2 = new Embed2(Collections.singletonList(new Embed3("s3", "s4")));
+        Embed1 record = new Embed1(Collections.singletonList(embed2), new Embed3("s1", "s2"), "id");
+        AeroMapper mapper = new AeroMapper.Builder(client).build();
+
+        mapper.save(record);
+        Embed1 read = mapper.read(Embed1.class, record.getId());
+        assertEquals(record, read);
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @AerospikeRecord(namespace = "test", set = "embed")
+    private static class Embed1 {
+        @AerospikeEmbed
+        public List<Embed2> bList;
+        @AerospikeEmbed
+        private Embed3 embed3;
+        @AerospikeKey
+        private String id;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class Embed2 {
+        @AerospikeEmbed
+        public List<Embed3> cList;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class Embed3 {
+        public String s1;
+        public String s2;
+    }
+}

--- a/src/test/java/com/aerospike/mapper/EmbeddedClassTest.java
+++ b/src/test/java/com/aerospike/mapper/EmbeddedClassTest.java
@@ -6,6 +6,8 @@ import com.aerospike.mapper.annotations.AerospikeRecord;
 import com.aerospike.mapper.tools.AeroMapper;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class EmbeddedClassTest extends AeroMapperBaseTest {
 
     @Test
-    void test() {
+    void testEmbed() {
         Embed2 embed2 = new Embed2(Collections.singletonList(new Embed3("s3", "s4")));
         Embed1 record = new Embed1(Collections.singletonList(embed2), new Embed3("s1", "s2"), "id");
         AeroMapper mapper = new AeroMapper.Builder(client).build();
@@ -25,6 +27,16 @@ public class EmbeddedClassTest extends AeroMapperBaseTest {
         mapper.save(record);
         Embed1 read = mapper.read(Embed1.class, record.getId());
         assertEquals(record, read);
+    }
+
+    @Test
+    void testDerived() {
+        Derived derived = new Derived("str1", 1);
+        AeroMapper mapper = new AeroMapper.Builder(client).build();
+
+        mapper.save(derived);
+        Derived read = mapper.read(Derived.class, derived.getStr());
+        assertEquals(derived, read);
     }
 
     @Data
@@ -43,6 +55,7 @@ public class EmbeddedClassTest extends AeroMapperBaseTest {
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
+    @AerospikeRecord // test backward
     private static class Embed2 {
         @AerospikeEmbed
         public List<Embed3> cList;
@@ -54,5 +67,26 @@ public class EmbeddedClassTest extends AeroMapperBaseTest {
     private static class Embed3 {
         public String s1;
         public String s2;
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @Getter
+    @NoArgsConstructor
+    @AerospikeRecord(namespace = "test", set = "embed")
+    private static class Derived extends Base {
+        @AerospikeKey
+        private String str;
+
+        Derived(String str, int i1) {
+            super(i1);
+            this.str = str;
+        }
+    }
+
+    @EqualsAndHashCode
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class Base {
+        private int i1;
     }
 }


### PR DESCRIPTION
This PR adds support for having embedded POJOs without the need to annotate them as `AerospikeRecord` (#118). This makes sense as they represent a bin/nested CDT within a record and not a record.