### PR TITLE
Remove block hound - inactive project, last commit was on April 2021.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
 		<jackson-dataformat-yaml.version>2.13.4</jackson-dataformat-yaml.version>
 		<lombok.version>1.18.24</lombok.version>
 		<reactor-test.version>3.4.23</reactor-test.version>
-		<blockhound.version>1.0.6.RELEASE</blockhound.version>
 		<junit-jupiter.version>5.9.1</junit-jupiter.version>
 	</properties>
 
@@ -123,12 +122,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>io.projectreactor.tools</groupId>
-			<artifactId>blockhound</artifactId>
-			<version>${blockhound.version}</version>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>

--- a/src/test/java/com/aerospike/mapper/reactive/ReactiveAeroMapperBaseTest.java
+++ b/src/test/java/com/aerospike/mapper/reactive/ReactiveAeroMapperBaseTest.java
@@ -5,7 +5,6 @@ import com.aerospike.client.reactor.IAerospikeReactorClient;
 import com.aerospike.mapper.AeroMapperBaseTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import reactor.blockhound.BlockHound;
 
 import java.io.IOException;
 
@@ -22,10 +21,5 @@ public class ReactiveAeroMapperBaseTest extends AeroMapperBaseTest {
         if (reactorClient != null) {
             reactorClient.close();
         }
-    }
-
-    @BeforeAll
-    public static void installBlockHound() {
-        BlockHound.install();
     }
 }


### PR DESCRIPTION
BlockHound also complicates our build/releases and in special cases conflicts with some Spring annotations such as @TestInstance(TestInstance.Lifecycle.PER_CLASS) with reactive flow.