### PR TITLE
Allowed classes to have no attributes

### DIFF
--- a/src/main/java/com/aerospike/mapper/tools/ClassCacheEntry.java
+++ b/src/main/java/com/aerospike/mapper/tools/ClassCacheEntry.java
@@ -1,5 +1,24 @@
 package com.aerospike.mapper.tools;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.lang3.StringUtils;
+
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Bin;
 import com.aerospike.client.Key;
@@ -11,7 +30,15 @@ import com.aerospike.client.policy.Policy;
 import com.aerospike.client.policy.QueryPolicy;
 import com.aerospike.client.policy.ScanPolicy;
 import com.aerospike.client.policy.WritePolicy;
-import com.aerospike.mapper.annotations.*;
+import com.aerospike.mapper.annotations.AerospikeBin;
+import com.aerospike.mapper.annotations.AerospikeConstructor;
+import com.aerospike.mapper.annotations.AerospikeExclude;
+import com.aerospike.mapper.annotations.AerospikeGetter;
+import com.aerospike.mapper.annotations.AerospikeKey;
+import com.aerospike.mapper.annotations.AerospikeOrdinal;
+import com.aerospike.mapper.annotations.AerospikeRecord;
+import com.aerospike.mapper.annotations.AerospikeSetter;
+import com.aerospike.mapper.annotations.ParamFrom;
 import com.aerospike.mapper.exceptions.NotAnnotatedClass;
 import com.aerospike.mapper.tools.configuration.BinConfig;
 import com.aerospike.mapper.tools.configuration.ClassConfig;
@@ -19,16 +46,6 @@ import com.aerospike.mapper.tools.configuration.KeyConfig;
 import com.aerospike.mapper.tools.utils.ParserUtils;
 import com.aerospike.mapper.tools.utils.TypeUtils;
 import com.aerospike.mapper.tools.utils.TypeUtils.AnnotatedType;
-import org.apache.commons.lang3.StringUtils;
-
-import javax.validation.constraints.NotNull;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Parameter;
-import java.util.*;
 
 public class ClassCacheEntry<T> {
 
@@ -129,10 +146,6 @@ public class ClassCacheEntry<T> {
         this.loadPropertiesFromClass();
         this.superClazz = ClassCache.getInstance().loadClass(this.clazz.getSuperclass(), this.mapper, !this.mapAll);
         this.binCount = this.values.size() + (superClazz != null ? superClazz.binCount : 0);
-        if (this.binCount == 0) {
-            throw new AerospikeException(String.format("Class %s has no values defined to be stored in the database",
-                    clazz.getSimpleName()));
-        }
         this.formOrdinalsFromValues();
         Method factoryConstructorMethod = findConstructorFactoryMethod();
         if (factoryConstructorMethod == null) {
@@ -773,6 +786,9 @@ public class ClassCacheEntry<T> {
     }
 
     public Integer getTtl() {
+    	if (ttl == null || ttl == Integer.MIN_VALUE) {
+    		return null;
+    	}
         return ttl;
     }
 

--- a/src/test/java/com/aerospike/mapper/BaseClassWithNoAttributesTest.java
+++ b/src/test/java/com/aerospike/mapper/BaseClassWithNoAttributesTest.java
@@ -1,0 +1,129 @@
+package com.aerospike.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.aerospike.mapper.annotations.AerospikeBin;
+import com.aerospike.mapper.annotations.AerospikeEmbed;
+import com.aerospike.mapper.annotations.AerospikeEmbed.EmbedType;
+import com.aerospike.mapper.annotations.AerospikeKey;
+import com.aerospike.mapper.annotations.AerospikeRecord;
+import com.aerospike.mapper.tools.AeroMapper;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class BaseClassWithNoAttributesTest extends AeroMapperBaseTest {
+	
+	public static class Animal {
+	}
+	
+	@Data
+	@AllArgsConstructor
+	@AerospikeRecord(namespace = "test", set = "zoo")
+	public static class Dog extends Animal{
+		
+		@AerospikeKey
+		private String dogId;
+	    private String breed;
+	    
+	    public Dog(){
+			dogId = "" + ((int) (Math.random() * 1000));
+	    }
+	    
+	    public Dog(String breed) {
+	    	this.breed = breed;
+			dogId = "" + ((int) (Math.random() * 1000));
+	    }
+	    
+	    public String getBreed() {
+			return breed;
+		}
+	    
+	    public String getDogId() {
+			return dogId;
+		}
+	}
+	
+	@Data
+	@AllArgsConstructor
+	@AerospikeRecord(namespace = "test", set = "zoo")
+	public static class Cat extends Animal {
+		
+		@AerospikeKey
+		private String catId;
+		private String breed;
+		private String lifeSpan;
+
+		public Cat(String breed, String lifeSpan) {
+			this.breed = breed;
+			this.lifeSpan = lifeSpan;
+			
+			catId = "" + ((int) (Math.random() * 1000));
+		}
+
+		public Cat() {
+			catId = "" + ((int) (Math.random() * 1000));
+		}
+		
+		public String getBreed() {
+			return breed;
+		}
+		
+		public String getCatId() {
+			return catId;
+		}
+		
+		public String getLifeSpan() {
+			return lifeSpan;
+		}
+	}
+
+	@AerospikeRecord(namespace = "test", set = "zoo", mapAll = false)
+	@NoArgsConstructor
+	@Data
+	public static class Zoo {
+
+		@AerospikeBin
+		@AerospikeKey
+		private String zooId;
+
+		@AerospikeBin
+		@AerospikeEmbed(type = EmbedType.LIST, elementType = EmbedType.MAP)
+		private List<Animal> animalsList;
+
+		public Zoo(String zooId, List<Animal> animalsList) {
+			super();
+			this.zooId = zooId;
+			this.animalsList = animalsList;
+		}
+	}
+	
+	
+	@Test
+	public void runTest() {
+		AeroMapper mapper = new AeroMapper.Builder(client).build();
+		
+		Zoo zoo = new Zoo();
+		zoo.setZooId("103");
+		
+		List<Animal> listOfAnimals = new ArrayList<>();
+		listOfAnimals.add(new Cat("Persian", "30"));
+		listOfAnimals.add(new Cat("Indian", "21"));
+		listOfAnimals.add(new Dog("Lab"));
+		listOfAnimals.add(new Cat("Korean", "15"));
+		listOfAnimals.add(new Dog("Desi"));
+		
+		zoo.setAnimalsList(listOfAnimals);
+		mapper.save(zoo);
+
+		Zoo readZoo = mapper.read(Zoo.class, "103");
+		assertEquals(zoo.zooId, readZoo.zooId);
+		assertEquals(zoo, readZoo);
+	}
+}


### PR DESCRIPTION
An error message was thrown if a class had no immediate or superclass attributes to be saved to the database. This is a valid check on a low level class, but it's entirely fair to have a superclass (typically abstract) which has no attributes, and this error was being thrown here too as the hierarchy is traversed upwards recursively

The check is safe to remove as it's illegal to save a class with no attributes to the database because there will be no @Id field so will throw an exception anyway.