### PR TITLE
Support interface superclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The documentation for this project can be found on [javadoc.io](https://www.java
     + 9.2. [Subclasses](#Subclasses)
         + 9.2.1. [Data Inheritance](#Data-Inheritance)
         + 9.2.2. [Subclass Inheritance](#Subclass-Inheritance)
+        + 9.2.3 [Using Interfaces](#Using-Interfaces)        
     + 9.3. [Custom Object Converters](#Custom-Object-Converters)
 10. [External Configuration File](#External-Configuration-File)
     + 10.1. [File Structure](#File-Structure)
@@ -1704,6 +1705,14 @@ public List customers;
 
 The former is considered better style in Java and also provides the Java Object Mapper with information about the elements in the list, so it will optimize its workings to know how to store a list of Customers. The latter gives it no type information so it must derive the type -- and hence how to map it to Aerospike -- for every element in this list. This can have a noticeable performance impact for large lists, as well as consuming more database space (as it must store the runtime type of each element in the list in addition to the data).
 
+### Using Interfaces
+Sometimes it is better to have an interface to group common types rather an an abstract superclass. In this case the Object Mapper supports placing the `@AerospikeReocrd` annotation on the interface and it will behave as if the annotation was on a superclass. There are multiple different was of placing the `@AerospikeRecord` annotation on a single class, and the order the Object Mapper looks for them in is:
+1. Configuration file
+2. Class level definition
+3. First parent class with `@AerospikeRecord` annotation (of any ancestor)
+4. Interface with `@AerospikeRecord` annotation (first one found)
+
+Once the Object Mapper finds an appropriate annotation it ignores any further annotations and uses the definitions on the first one found.
 
 ----
 

--- a/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
@@ -634,4 +634,28 @@ public class AeroMapper implements IAeroMapper {
                 throw new UnsupportedOperationException("Provided unsupported policy.");
         }
     }
+
+    @Override
+    public String getNamespace(Class<?> clazz) {
+        ClassCacheEntry<?> entry = ClassCache.getInstance().loadClass(clazz, this);
+        return entry == null ? null : entry.getNamespace();
+    }
+
+    @Override
+    public String getSet(Class<?> clazz) {
+        ClassCacheEntry<?> entry = ClassCache.getInstance().loadClass(clazz, this);
+        return entry == null ? null : entry.getSetName();
+    }
+
+    @Override
+    public Object getKey(Object obj) {
+        ClassCacheEntry<?> entry = ClassCache.getInstance().loadClass(obj.getClass(), this);
+        return entry == null ? null : entry.getKey(obj);
+    }
+
+    @Override
+    public Key getRecordKey(Object obj) {
+        ClassCacheEntry<?> entry = ClassCache.getInstance().loadClass(obj.getClass(), this);
+        return entry == null ? null : new Key(entry.getNamespace(), entry.getSetName(), Value.get(entry.getKey(obj)));
+    }
 }

--- a/src/main/java/com/aerospike/mapper/tools/ClassCache.java
+++ b/src/main/java/com/aerospike/mapper/tools/ClassCache.java
@@ -45,7 +45,8 @@ public class ClassCache {
 
     @SuppressWarnings("unchecked")
     public <T> ClassCacheEntry<T> loadClass(@NotNull Class<T> clazz, IBaseAeroMapper mapper, boolean requireRecord) {
-        if (clazz.isPrimitive() || clazz.equals(Object.class) || clazz.equals(String.class)
+        // Clazz can be null if an interface is passed
+        if (clazz == null || clazz.isPrimitive() || clazz.equals(Object.class) || clazz.equals(String.class)
                 || clazz.equals(Character.class) || Number.class.isAssignableFrom(clazz)) {
             return null;
         }

--- a/src/main/java/com/aerospike/mapper/tools/ClassCacheEntry.java
+++ b/src/main/java/com/aerospike/mapper/tools/ClassCacheEntry.java
@@ -80,7 +80,6 @@ public class ClassCacheEntry<T> {
     private Object[] constructorParamDefaults;
     private Constructor<T> constructor;
     private final ClassConfig config;
-    private List<AerospikeRecord> aerospikeInterfaceRecords;
 
     private String factoryMethod;
     private String factoryClass;
@@ -134,9 +133,11 @@ public class ClassCacheEntry<T> {
             this.overrideSettings(config);
         }
 
-        this.aerospikeInterfaceRecords = this.loadAerospikeRecordsFromInterfaces(this.clazz);
-        for (int i = 0; (this.namespace == null || this.namespace.isEmpty()) && i < aerospikeInterfaceRecords.size(); i++) {
-            this.setPropertiesFromAerospikeRecord(aerospikeInterfaceRecords.get(i));
+        if (this.namespace == null || this.namespace.isEmpty()) {
+            List<AerospikeRecord> aerospikeInterfaceRecords = this.loadAerospikeRecordsFromInterfaces(this.clazz);
+            for (int i = 0; (this.namespace == null || this.namespace.isEmpty()) && i < aerospikeInterfaceRecords.size(); i++) {
+                this.setPropertiesFromAerospikeRecord(aerospikeInterfaceRecords.get(i));
+            }
         }
         this.loadFieldsFromClass();
         this.loadPropertiesFromClass();

--- a/src/main/java/com/aerospike/mapper/tools/ClassCacheEntry.java
+++ b/src/main/java/com/aerospike/mapper/tools/ClassCacheEntry.java
@@ -1,5 +1,24 @@
 package com.aerospike.mapper.tools;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.lang3.StringUtils;
+
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Bin;
 import com.aerospike.client.Key;
@@ -11,7 +30,15 @@ import com.aerospike.client.policy.Policy;
 import com.aerospike.client.policy.QueryPolicy;
 import com.aerospike.client.policy.ScanPolicy;
 import com.aerospike.client.policy.WritePolicy;
-import com.aerospike.mapper.annotations.*;
+import com.aerospike.mapper.annotations.AerospikeBin;
+import com.aerospike.mapper.annotations.AerospikeConstructor;
+import com.aerospike.mapper.annotations.AerospikeExclude;
+import com.aerospike.mapper.annotations.AerospikeGetter;
+import com.aerospike.mapper.annotations.AerospikeKey;
+import com.aerospike.mapper.annotations.AerospikeOrdinal;
+import com.aerospike.mapper.annotations.AerospikeRecord;
+import com.aerospike.mapper.annotations.AerospikeSetter;
+import com.aerospike.mapper.annotations.ParamFrom;
 import com.aerospike.mapper.exceptions.NotAnnotatedClass;
 import com.aerospike.mapper.tools.configuration.BinConfig;
 import com.aerospike.mapper.tools.configuration.ClassConfig;
@@ -19,16 +46,6 @@ import com.aerospike.mapper.tools.configuration.KeyConfig;
 import com.aerospike.mapper.tools.utils.ParserUtils;
 import com.aerospike.mapper.tools.utils.TypeUtils;
 import com.aerospike.mapper.tools.utils.TypeUtils.AnnotatedType;
-import org.apache.commons.lang3.StringUtils;
-
-import javax.validation.constraints.NotNull;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Parameter;
-import java.util.*;
 
 public class ClassCacheEntry<T> {
 
@@ -63,6 +80,7 @@ public class ClassCacheEntry<T> {
     private Object[] constructorParamDefaults;
     private Constructor<T> constructor;
     private final ClassConfig config;
+    private List<AerospikeRecord> aerospikeInterfaceRecords;
 
     private String factoryMethod;
     private String factoryClass;
@@ -105,16 +123,7 @@ public class ClassCacheEntry<T> {
             throw new NotAnnotatedClass(String.format("Class %s is not augmented by the @AerospikeRecord annotation",
                     clazz.getName()));
         } else if (recordDescription != null) {
-            this.namespace = ParserUtils.getInstance().get(recordDescription.namespace());
-            this.setName = ParserUtils.getInstance().get(recordDescription.set());
-            this.ttl = recordDescription.ttl();
-            this.mapAll = recordDescription.mapAll();
-            this.version = recordDescription.version();
-            this.sendKey = recordDescription.sendKey();
-            this.durableDelete = recordDescription.durableDelete();
-            this.shortenedClassName = recordDescription.shortName();
-            this.factoryClass = recordDescription.factoryClass();
-            this.factoryMethod = recordDescription.factoryMethod();
+            this.setPropertiesFromAerospikeRecord(recordDescription);
         }
         this.config = config;
     }
@@ -125,20 +134,26 @@ public class ClassCacheEntry<T> {
             this.overrideSettings(config);
         }
 
+        this.aerospikeInterfaceRecords = this.loadAerospikeRecordsFromInterfaces(this.clazz);
+        for (int i = 0; (this.namespace == null || this.namespace.isEmpty()) && i < aerospikeInterfaceRecords.size(); i++) {
+            this.setPropertiesFromAerospikeRecord(aerospikeInterfaceRecords.get(i));
+        }
         this.loadFieldsFromClass();
         this.loadPropertiesFromClass();
         this.superClazz = ClassCache.getInstance().loadClass(this.clazz.getSuperclass(), this.mapper, !this.mapAll);
         this.binCount = this.values.size() + (superClazz != null ? superClazz.binCount : 0);
-        if (this.binCount == 0) {
-            throw new AerospikeException(String.format("Class %s has no values defined to be stored in the database",
-                    clazz.getSimpleName()));
-        }
+//        if (this.binCount == 0) {
+//            throw new AerospikeException(String.format("Class %s has no values defined to be stored in the database",
+//                    clazz.getSimpleName()));
+//        }
         this.formOrdinalsFromValues();
         Method factoryConstructorMethod = findConstructorFactoryMethod();
-        if (factoryConstructorMethod == null) {
-            this.findConstructor();
-        } else {
-            this.setConstructorFactoryMethod(factoryConstructorMethod);
+        if (!this.clazz.isInterface()) {
+            if (factoryConstructorMethod == null) {
+                this.findConstructor();
+            } else {
+                this.setConstructorFactoryMethod(factoryConstructorMethod);
+            }
         }
         if (StringUtils.isBlank(this.shortenedClassName)) {
             this.shortenedClassName = clazz.getSimpleName();
@@ -221,6 +236,33 @@ public class ClassCacheEntry<T> {
 
     public boolean isChildClass() {
         return isChildClass;
+    }
+
+    private List<AerospikeRecord> loadAerospikeRecordsFromInterfaces(Class<?> clazz) {
+        List<AerospikeRecord> results = new ArrayList<>();
+        Class<?>[] interfaces = clazz.getInterfaces();
+        for (int i = 0; i < interfaces.length; i++) {
+            Class<?> thisInterface = interfaces[i];
+            AerospikeRecord[] aerospikeRecords = thisInterface.getAnnotationsByType(AerospikeRecord.class);
+            for (int j = 0; j < aerospikeRecords.length; j++) {
+                results.add(aerospikeRecords[j]);
+            }
+            results.addAll(loadAerospikeRecordsFromInterfaces(thisInterface));
+        }
+        return results;
+    }
+    
+    private void setPropertiesFromAerospikeRecord(AerospikeRecord recordDescription) {
+        this.namespace = ParserUtils.getInstance().get(recordDescription.namespace());
+        this.setName = ParserUtils.getInstance().get(recordDescription.set());
+        this.ttl = recordDescription.ttl();
+        this.mapAll = recordDescription.mapAll();
+        this.version = recordDescription.version();
+        this.sendKey = recordDescription.sendKey();
+        this.durableDelete = recordDescription.durableDelete();
+        this.shortenedClassName = recordDescription.shortName();
+        this.factoryClass = recordDescription.factoryClass();
+        this.factoryMethod = recordDescription.factoryMethod();
     }
 
     private void checkRecordSettingsAgainstSuperClasses() {

--- a/src/main/java/com/aerospike/mapper/tools/IAeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/IAeroMapper.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotNull;
 
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.IAerospikeClient;
+import com.aerospike.client.Key;
 import com.aerospike.client.Operation;
 import com.aerospike.client.policy.BatchPolicy;
 import com.aerospike.client.policy.Policy;
@@ -392,5 +393,35 @@ public interface IAeroMapper extends IBaseAeroMapper {
      */
     <T> VirtualList<T> asBackedList(@NotNull Class<?> owningClazz, @NotNull Object key, @NotNull String binName, Class<T> elementClazz);
 
+    /**
+     * Get the IAerospikeClient which was used to create this mapper.
+     * @return the underlying mapper.
+     */
     IAerospikeClient getClient();
+    
+    /**
+     * Get the namespace associated with the passed class
+     * @param clazz - the class to retrieve the namespace of
+     * @return the namespace
+     */
+    String getNamespace(Class<?> clazz);
+
+    /**
+     * Get the set associated with the passed class
+     * @param clazz - the class to retrieve the set of
+     * @return the set
+     */
+    String getSet(Class<?> clazz);
+    
+    /**
+     * Get the primary id associated with the passed object
+     */
+    Object getKey(Object obj);
+    
+    /**
+     * Get the Aerospike Key used to read the record associated with the passed key
+     * @param obj - the object to return the key of
+     * @return the key which could be used to retrieve this record.
+     */
+    Key getRecordKey(Object obj);
 }

--- a/src/main/java/com/aerospike/mapper/tools/IReactiveAeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/IReactiveAeroMapper.java
@@ -1,16 +1,23 @@
 package com.aerospike.mapper.tools;
 
+import java.util.function.Function;
+
+import javax.validation.constraints.NotNull;
+
 import com.aerospike.client.AerospikeException;
+import com.aerospike.client.Key;
 import com.aerospike.client.Operation;
-import com.aerospike.client.policy.*;
+import com.aerospike.client.policy.BatchPolicy;
+import com.aerospike.client.policy.Policy;
+import com.aerospike.client.policy.QueryPolicy;
+import com.aerospike.client.policy.ScanPolicy;
+import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.query.Filter;
 import com.aerospike.client.reactor.IAerospikeReactorClient;
 import com.aerospike.mapper.tools.virtuallist.ReactiveVirtualList;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import javax.validation.constraints.NotNull;
-import java.util.function.Function;
 
 public interface IReactiveAeroMapper extends IBaseAeroMapper {
 
@@ -321,4 +328,30 @@ public interface IReactiveAeroMapper extends IBaseAeroMapper {
     <T> ReactiveVirtualList<T> asBackedList(@NotNull Class<?> owningClazz, @NotNull Object key, @NotNull String binName, Class<T> elementClazz);
 
     IAerospikeReactorClient getReactorClient();
+    /**
+     * Get the namespace associated with the passed class
+     * @param clazz - the class to retrieve the namespace of
+     * @return the namespace
+     */
+    <T> Mono<String> getNamespace(Class<T> clazz);
+
+    /**
+     * Get the set associated with the passed class
+     * @param clazz - the class to retrieve the set of
+     * @return the set
+     */
+    <T> Mono<String> getSet(Class<T> clazz);
+    
+    /**
+     * Get the primary id associated with the passed object
+     */
+    Mono<Object> getKey(Object obj);
+    
+    /**
+     * Get the Aerospike Key used to read the record associated with the passed key
+     * 
+     * @param obj - the object to return the key of
+     * @return the key which could be used to retrieve this record.
+     */
+    Mono<Key> getRecordKey(Object obj);
 }

--- a/src/main/java/com/aerospike/mapper/tools/ReactiveAeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/ReactiveAeroMapper.java
@@ -556,4 +556,28 @@ public class ReactiveAeroMapper implements IReactiveAeroMapper {
         }
         return e;
     }
+    
+    @Override
+    public <T> Mono<String> getNamespace(Class<T> clazz) {
+        ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
+        return entry == null ? null : Mono.just(entry.getNamespace());
+    }
+
+    @Override
+    public <T> Mono<String> getSet(Class<T> clazz) {
+        ClassCacheEntry<?> entry = ClassCache.getInstance().loadClass(clazz, this);
+        return entry == null ? null : Mono.just(entry.getSetName());
+    }
+
+    @Override
+    public Mono<Object> getKey(Object obj) {
+        ClassCacheEntry<?> entry = ClassCache.getInstance().loadClass(obj.getClass(), this);
+        return entry == null ? null : Mono.just(entry.getKey(obj));
+    }
+
+    @Override
+    public Mono<Key> getRecordKey(Object obj) {
+        ClassCacheEntry<?> entry = ClassCache.getInstance().loadClass(obj.getClass(), this);
+        return entry == null ? null : Mono.just(new Key(entry.getNamespace(), entry.getSetName(), Value.get(entry.getKey(obj))));
+    }
 }

--- a/src/test/java/com/aerospike/mapper/InterfaceHierarchyTest.java
+++ b/src/test/java/com/aerospike/mapper/InterfaceHierarchyTest.java
@@ -1,0 +1,127 @@
+package com.aerospike.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.aerospike.mapper.annotations.AerospikeEmbed;
+import com.aerospike.mapper.annotations.AerospikeKey;
+import com.aerospike.mapper.annotations.AerospikeRecord;
+import com.aerospike.mapper.tools.AeroMapper;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class InterfaceHierarchyTest extends AeroMapperBaseTest {
+    @AerospikeRecord(set = "testSet", namespace = "test")
+    public static interface BaseInterface {
+        String getName();
+    }
+
+    @AerospikeRecord
+    @NoArgsConstructor
+    @Data
+    public static class SubClass1 implements BaseInterface {
+        @AerospikeKey
+        private String myName;
+        public SubClass1(String myName) {
+            this.myName = myName;
+        }
+        @Override
+        public String getName() {
+            return myName;
+        }
+        @Override
+        public String toString() {
+            return "SubClass1: " + myName;
+        }
+    }
+    @AerospikeRecord
+    @NoArgsConstructor
+    @Data
+    public static class SubClass2 implements BaseInterface {
+        @AerospikeKey
+        private String myName;
+        public SubClass2(String myName) {
+            this.myName = myName;
+        }
+        @Override
+        public String getName() {
+            return myName;
+        }
+        @Override
+        public String toString() {
+            return "SubClass2: " + myName;
+        }
+    }
+    
+    @AerospikeRecord(set="container", namespace = "test")
+    @Data
+    public static class Container {
+        @AerospikeKey
+        private long id;
+        private final List<BaseInterface> children;
+        public Container() {
+            this.children = new ArrayList<>();
+            this.id = 1;
+        }
+        public Container(BaseInterface firstChild, BaseInterface ... otherChildren) {
+            this();
+            this.children.add(firstChild);
+            for (int i = 0; i < otherChildren.length; i++) {
+                this.children.add(otherChildren[i]);
+            }
+        }
+    }
+
+    @AerospikeRecord(set="container", namespace = "test")
+    @Data
+    public static class NestedContainer {
+        @AerospikeKey
+        private long id;
+        @AerospikeEmbed
+        private final List<BaseInterface> children;
+        public NestedContainer() {
+            this.children = new ArrayList<>();
+            this.id = 2;
+        }
+        public NestedContainer(BaseInterface firstChild, BaseInterface ... otherChildren) {
+            this();
+            this.children.add(firstChild);
+            for (int i = 0; i < otherChildren.length; i++) {
+                this.children.add(otherChildren[i]);
+            }
+        }
+    }
+
+    @Test
+    public void runTest() {
+        AeroMapper mapper = new AeroMapper.Builder(client).build();
+        Container container = new Container(
+                new SubClass1("Bob"),
+                new SubClass2("Fred"),
+                new SubClass1("Wilma")
+        );
+        
+        mapper.save(container, container.children.get(0), container.children.get(1), container.children.get(2));
+        Container readContainer = mapper.read(Container.class, 1);
+        assertEquals(container, readContainer);
+    }
+
+    @Test
+    public void runNestedTest() {
+        AeroMapper mapper = new AeroMapper.Builder(client).build();
+        NestedContainer container = new NestedContainer(
+                new SubClass1("Bob"),
+                new SubClass2("Fred"),
+                new SubClass1("Wilma")
+        );
+        
+        mapper.save(container, container.children.get(0), container.children.get(1), container.children.get(2));
+        NestedContainer readContainer = mapper.read(NestedContainer.class, 2);
+        assertEquals(container, readContainer);
+    }
+}

--- a/src/test/java/com/aerospike/mapper/InterfaceHierarchyTest.java
+++ b/src/test/java/com/aerospike/mapper/InterfaceHierarchyTest.java
@@ -3,6 +3,7 @@ package com.aerospike.mapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -89,9 +90,7 @@ public class InterfaceHierarchyTest extends AeroMapperBaseTest {
         public NestedContainer(BaseInterface firstChild, BaseInterface ... otherChildren) {
             this();
             this.children.add(firstChild);
-            for (int i = 0; i < otherChildren.length; i++) {
-                this.children.add(otherChildren[i]);
-            }
+            this.children.addAll(Arrays.asList(otherChildren));
         }
     }
 
@@ -118,7 +117,7 @@ public class InterfaceHierarchyTest extends AeroMapperBaseTest {
                 new SubClass1("Wilma")
         );
         
-        mapper.save(container, container.children.get(0), container.children.get(1), container.children.get(2));
+        mapper.save(container);
         NestedContainer readContainer = mapper.read(NestedContainer.class, 2);
         assertEquals(container, readContainer);
     }

--- a/src/test/java/com/aerospike/mapper/InterfaceHierarchyTest.java
+++ b/src/test/java/com/aerospike/mapper/InterfaceHierarchyTest.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 
 public class InterfaceHierarchyTest extends AeroMapperBaseTest {
     @AerospikeRecord(set = "testSet", namespace = "test")
-    public static interface BaseInterface {
+    public interface BaseInterface {
         String getName();
     }
 
@@ -71,9 +71,7 @@ public class InterfaceHierarchyTest extends AeroMapperBaseTest {
         public Container(BaseInterface firstChild, BaseInterface ... otherChildren) {
             this();
             this.children.add(firstChild);
-            for (int i = 0; i < otherChildren.length; i++) {
-                this.children.add(otherChildren[i]);
-            }
+            this.children.addAll(Arrays.asList(otherChildren));
         }
     }
 

--- a/src/test/java/com/aerospike/mapper/reactive/ReactiveInterfaceHierarchyTest.java
+++ b/src/test/java/com/aerospike/mapper/reactive/ReactiveInterfaceHierarchyTest.java
@@ -122,7 +122,7 @@ public class ReactiveInterfaceHierarchyTest extends ReactiveAeroMapperBaseTest {
                 new SubClass1("Wilma")
         );
         
-        reactiveMapper.save(container);
+        reactiveMapper.save(container).subscribeOn(Schedulers.parallel()).block();
         NestedContainer readContainer = reactiveMapper.read(NestedContainer.class, 2).subscribeOn(Schedulers.parallel()).block();
         assertEquals(container, readContainer);
     }

--- a/src/test/java/com/aerospike/mapper/reactive/ReactiveInterfaceHierarchyTest.java
+++ b/src/test/java/com/aerospike/mapper/reactive/ReactiveInterfaceHierarchyTest.java
@@ -16,6 +16,8 @@ import com.aerospike.mapper.tools.ReactiveAeroMapper;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 
 public class ReactiveInterfaceHierarchyTest extends ReactiveAeroMapperBaseTest {
     @AerospikeRecord(set = "testSet", namespace = "test")
@@ -105,8 +107,9 @@ public class ReactiveInterfaceHierarchyTest extends ReactiveAeroMapperBaseTest {
                 new SubClass1("Wilma")
         );
         
-        reactiveMapper.save(container);
-        Container readContainer = reactiveMapper.read(Container.class, 1).block();
+        reactiveMapper.save(container, container.getChildren().get(0), container.getChildren().get(1), container.getChildren().get(2))
+                .subscribeOn(Schedulers.parallel()).blockLast();
+        Container readContainer = reactiveMapper.read(Container.class, 1).subscribeOn(Schedulers.parallel()).block();
         assertEquals(container, readContainer);
     }
 
@@ -120,7 +123,7 @@ public class ReactiveInterfaceHierarchyTest extends ReactiveAeroMapperBaseTest {
         );
         
         reactiveMapper.save(container);
-        NestedContainer readContainer = reactiveMapper.read(NestedContainer.class, 2).block();
+        NestedContainer readContainer = reactiveMapper.read(NestedContainer.class, 2).subscribeOn(Schedulers.parallel()).block();
         assertEquals(container, readContainer);
     }
 }

--- a/src/test/java/com/aerospike/mapper/reactive/ReactiveInterfaceHierarchyTest.java
+++ b/src/test/java/com/aerospike/mapper/reactive/ReactiveInterfaceHierarchyTest.java
@@ -1,0 +1,126 @@
+package com.aerospike.mapper.reactive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.aerospike.mapper.annotations.AerospikeEmbed;
+import com.aerospike.mapper.annotations.AerospikeKey;
+import com.aerospike.mapper.annotations.AerospikeRecord;
+import com.aerospike.mapper.tools.AeroMapper;
+import com.aerospike.mapper.tools.ReactiveAeroMapper;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class ReactiveInterfaceHierarchyTest extends ReactiveAeroMapperBaseTest {
+    @AerospikeRecord(set = "testSet", namespace = "test")
+    public interface BaseInterface {
+        String getName();
+    }
+
+    @AerospikeRecord
+    @NoArgsConstructor
+    @Data
+    public static class SubClass1 implements BaseInterface {
+        @AerospikeKey
+        private String myName;
+        public SubClass1(String myName) {
+            this.myName = myName;
+        }
+        @Override
+        public String getName() {
+            return myName;
+        }
+        @Override
+        public String toString() {
+            return "SubClass1: " + myName;
+        }
+    }
+    
+    @AerospikeRecord
+    @NoArgsConstructor
+    @Data
+    public static class SubClass2 implements BaseInterface {
+        @AerospikeKey
+        private String myName;
+        public SubClass2(String myName) {
+            this.myName = myName;
+        }
+        @Override
+        public String getName() {
+            return myName;
+        }
+        @Override
+        public String toString() {
+            return "SubClass2: " + myName;
+        }
+    }
+    
+    @AerospikeRecord(set="container", namespace = "test")
+    @Data
+    public static class Container {
+        @AerospikeKey
+        private long id;
+        private final List<BaseInterface> children;
+        public Container() {
+            this.children = new ArrayList<>();
+            this.id = 1;
+        }
+        public Container(BaseInterface firstChild, BaseInterface ... otherChildren) {
+            this();
+            this.children.add(firstChild);
+            this.children.addAll(Arrays.asList(otherChildren));
+        }
+    }
+
+    @AerospikeRecord(set="container", namespace = "test")
+    @Data
+    public static class NestedContainer {
+        @AerospikeKey
+        private long id;
+        @AerospikeEmbed
+        private final List<BaseInterface> children;
+        public NestedContainer() {
+            this.children = new ArrayList<>();
+            this.id = 2;
+        }
+        public NestedContainer(BaseInterface firstChild, BaseInterface ... otherChildren) {
+            this();
+            this.children.add(firstChild);
+            this.children.addAll(Arrays.asList(otherChildren));
+        }
+    }
+
+    @Test
+    public void runTest() {
+        ReactiveAeroMapper reactiveMapper = new ReactiveAeroMapper.Builder(reactorClient).build();
+        Container container = new Container(
+                new SubClass1("Bob"),
+                new SubClass2("Fred"),
+                new SubClass1("Wilma")
+        );
+        
+        reactiveMapper.save(container);
+        Container readContainer = reactiveMapper.read(Container.class, 1).block();
+        assertEquals(container, readContainer);
+    }
+
+    @Test
+    public void runNestedTest() {
+        ReactiveAeroMapper reactiveMapper = new ReactiveAeroMapper.Builder(reactorClient).build();
+        NestedContainer container = new NestedContainer(
+                new SubClass1("Bob"),
+                new SubClass2("Fred"),
+                new SubClass1("Wilma")
+        );
+        
+        reactiveMapper.save(container);
+        NestedContainer readContainer = reactiveMapper.read(NestedContainer.class, 2).block();
+        assertEquals(container, readContainer);
+    }
+}


### PR DESCRIPTION
Currently the Java Object Mapper only respects Classes for hierarchy roots. If there is no functionality on the superclass it would often be expressed as a interface rather than an abstract class. This new version supports reading the @AerospikeRecord annotation off the interfaces too. Order of priority is:

1. Configuration file
2. Record level definitions
3. First parent class with @AerospikeRecord
4. Interface with @AerospikeRecord