### PR TITLE
FMWK-467 Issue using refs with yaml file

### DIFF
--- a/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
@@ -78,7 +78,9 @@ public class AeroMapper implements IAeroMapper {
         ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
         if (writePolicy == null) {
             writePolicy = new WritePolicy(entry.getWritePolicy());
-            if (recordExistsAction != null) {
+            if (recordExistsAction != null && (writePolicy.recordExistsAction == null || writePolicy.recordExistsAction == RecordExistsAction.UPDATE)) {
+                // Override the default with the passed policy. Only do this if the policy is already at the default.
+                // Otherwise, "save" with an INSERT_ONLY policy would fail for example.
                 writePolicy.recordExistsAction = recordExistsAction;
             }
 

--- a/src/main/java/com/aerospike/mapper/tools/ReactiveAeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/ReactiveAeroMapper.java
@@ -74,7 +74,9 @@ public class ReactiveAeroMapper implements IReactiveAeroMapper {
         ClassCacheEntry<T> entry = MapperUtils.getEntryAndValidateNamespace(clazz, this);
         if (writePolicy == null) {
             writePolicy = new WritePolicy(entry.getWritePolicy());
-            if (recordExistsAction != null) {
+            if (recordExistsAction != null && (writePolicy.recordExistsAction == null || writePolicy.recordExistsAction == RecordExistsAction.UPDATE)) {
+                // Override the default with the passed policy. Only do this if the policy is already at the default.
+                // Otherwise, "save" with an INSERT_ONLY policy would fail for example.
                 writePolicy.recordExistsAction = recordExistsAction;
             }
             

--- a/src/main/java/com/aerospike/mapper/tools/configuration/ClassConfig.java
+++ b/src/main/java/com/aerospike/mapper/tools/configuration/ClassConfig.java
@@ -279,12 +279,12 @@ public class ClassConfig {
         }
         
         public Builder beingReferencedBy(AerospikeReference.ReferenceType type) {
-            this.binConfig.setReference(new ReferenceConfig(type, false));
+            this.binConfig.setReference(new ReferenceConfig(type, false, true));
             return this.end();
         }
         
         public Builder beingLazilyReferencedBy(AerospikeReference.ReferenceType type) {
-            this.binConfig.setReference(new ReferenceConfig(type, true));
+            this.binConfig.setReference(new ReferenceConfig(type, true, true));
             return this.end();
         }
         

--- a/src/main/java/com/aerospike/mapper/tools/configuration/ReferenceConfig.java
+++ b/src/main/java/com/aerospike/mapper/tools/configuration/ReferenceConfig.java
@@ -8,9 +8,10 @@ public class ReferenceConfig {
     private Boolean batchLoad;
 
     public ReferenceConfig() {}
-    public ReferenceConfig(ReferenceType type, boolean lazy) {
+    public ReferenceConfig(ReferenceType type, boolean lazy, boolean batchLoad) {
         this.type = type;
         this.lazy = lazy;
+        this.batchLoad = batchLoad;
     }
     
     public ReferenceType getType() {

--- a/src/main/java/com/aerospike/mapper/tools/utils/TypeUtils.java
+++ b/src/main/java/com/aerospike/mapper/tools/utils/TypeUtils.java
@@ -229,7 +229,11 @@ public class TypeUtils {
                         } else {
                             // Reference
                             ReferenceConfig ref = binConfig.getReference();
-                            typeMapper = new ObjectReferenceMapper(ClassCache.getInstance().loadClass(clazz, mapper), ref.getLazy(), ref.getBatchLoad(), ref.getType(), mapper);
+                            typeMapper = new ObjectReferenceMapper(
+                                    ClassCache.getInstance().loadClass(clazz, mapper), 
+                                    ref.getLazy() == null? false : ref.getLazy(), 
+                                    ref.getBatchLoad() == null ? true : ref.getBatchLoad(), 
+                                    ref.getType(), mapper);
                             addToMap = false;
                         }
                     } else {

--- a/src/test/java/com/aerospike/mapper/InsertOnlyModeTest.java
+++ b/src/test/java/com/aerospike/mapper/InsertOnlyModeTest.java
@@ -1,0 +1,71 @@
+package com.aerospike.mapper;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+import com.aerospike.client.AerospikeException;
+import com.aerospike.client.policy.ClientPolicy;
+import com.aerospike.client.policy.RecordExistsAction;
+import com.aerospike.client.policy.WritePolicy;
+import com.aerospike.mapper.annotations.AerospikeKey;
+import com.aerospike.mapper.annotations.AerospikeRecord;
+import com.aerospike.mapper.tools.AeroMapper;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class InsertOnlyModeTest extends AeroMapperBaseTest {
+    @AerospikeRecord(namespace = "test", set = "custs")
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Customer {
+        @AerospikeKey
+        private String name;
+        private int age;
+    }
+    
+    @Test
+    public void tetDefaultPolicies() {
+        WritePolicy writePolicy = new WritePolicy();
+        writePolicy.sendKey = true;
+        writePolicy.recordExistsAction=RecordExistsAction.CREATE_ONLY;
+        
+        ClientPolicy policy = new ClientPolicy();
+        policy.writePolicyDefault = writePolicy;
+        
+        AeroMapper mapper = new AeroMapper.Builder(client).withWritePolicy(writePolicy).forAll().build();
+        
+        Customer customer = new Customer("Tim", 312);
+        mapper.delete(customer);
+        // First one should succeed.
+        mapper.save(customer);
+        try {
+            mapper.save(customer);
+            fail("Expected an exception to be thrown");
+        }
+        catch (AerospikeException e) {
+        }
+    }
+    @Test
+    public void testExplicitPolicies() {
+        WritePolicy writePolicy = new WritePolicy();
+        writePolicy.sendKey = true;
+        writePolicy.recordExistsAction=RecordExistsAction.CREATE_ONLY;
+        
+        AeroMapper mapper = new AeroMapper.Builder(client).withWritePolicy(writePolicy).forAll().build();
+        
+        Customer customer = new Customer("Tim", 312);
+        mapper.delete(customer);
+        // First one should succeed.
+        mapper.save(customer);
+        try {
+            mapper.save(customer);
+            fail("Expected an exception to be thrown");
+        }
+        catch (AerospikeException e) {
+        }
+    }
+}

--- a/src/test/java/com/aerospike/mapper/reactive/ReactiveInsertOnlyModeTest.java
+++ b/src/test/java/com/aerospike/mapper/reactive/ReactiveInsertOnlyModeTest.java
@@ -1,0 +1,65 @@
+package com.aerospike.mapper.reactive;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+import com.aerospike.client.AerospikeException;
+import com.aerospike.client.policy.ClientPolicy;
+import com.aerospike.client.policy.RecordExistsAction;
+import com.aerospike.client.policy.WritePolicy;
+import com.aerospike.mapper.annotations.AerospikeKey;
+import com.aerospike.mapper.annotations.AerospikeRecord;
+import com.aerospike.mapper.tools.ReactiveAeroMapper;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class ReactiveInsertOnlyModeTest extends ReactiveAeroMapperBaseTest {
+    @AerospikeRecord(namespace = "test", set = "custs")
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Customer {
+        @AerospikeKey
+        private String name;
+        private int age;
+    }
+    
+    @Test
+    public void tetDefaultPolicies() {
+        WritePolicy writePolicy = new WritePolicy();
+        writePolicy.sendKey = true;
+        writePolicy.recordExistsAction=RecordExistsAction.CREATE_ONLY;
+        
+        ClientPolicy policy = new ClientPolicy();
+        policy.writePolicyDefault = writePolicy;
+        
+        ReactiveAeroMapper mapper = new ReactiveAeroMapper.Builder(reactorClient).withWritePolicy(writePolicy).forAll().build();
+        
+        Customer customer = new Customer("Tim", 312);
+        mapper.delete(customer);
+        // First one should succeed.
+        mapper.save(customer).doOnError(c -> fail("Expected an succcess"));
+        mapper.save(customer).doOnSuccess(c -> {
+            fail("Expected an exception to be thrown");
+        });
+    }
+    @Test
+    public void testExplicitPolicies() {
+        WritePolicy writePolicy = new WritePolicy();
+        writePolicy.sendKey = true;
+        writePolicy.recordExistsAction=RecordExistsAction.CREATE_ONLY;
+        
+        ReactiveAeroMapper mapper = new ReactiveAeroMapper.Builder(reactorClient).withWritePolicy(writePolicy).forAll().build();
+        
+        Customer customer = new Customer("Tim", 312);
+        mapper.delete(customer);
+        // First one should succeed.
+        mapper.save(customer).doOnError(c -> fail("Expected an succcess"));
+        mapper.save(customer).doOnSuccess(c -> {
+            fail("Expected an exception to be thrown");
+        });
+    }
+}


### PR DESCRIPTION
Fixed a null pointer exception when using refs via the YAML file, caused by BatchLoad being null and reading code incorrectly assuming a valid value. 