### PR TITLE
FMWK-468 Allow send key classes to use PK instead of Bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ public static class A {
 }
 ```
 
-there will be a bin in the database called `key`, whose value will be the same as the value used in the primary key. This is because Aerospike does not implicitly store the value of the key in the database, but rather uses a hash of the primary key  as a unique representation. So the value in the database might look like:
+there will be a bin in the database called `key`, whose value will be the same as the value used in the primary key. This is because Aerospike does not implicitly store the value of the key in the database, but rather uses a hash of the primary key as a unique representation. So the value in the database might look like:
 
 ```
 aql> select * from test.testSet

--- a/README.md
+++ b/README.md
@@ -511,14 +511,14 @@ aql> select * from test.testSet
 If it is desired to force the primary key to be stored in the database and NOT have key added explicitly as a column then two things must be set:
 
 1. The `@AerospikeRecord` annotation must have `sendKey = true`
-2. The `@AerospikeKey` annotation must have `storeInPkOnly = true`
+2. The `@AerospikeKey` annotation must have `storeAsBin = false`
 
 So the object would look like:
 
 ```java
 @AerospikeRecord(namespace = "test", set = "testSet", sendKey = true)
 public static class A {
-    @AerospikeKey(storeInPkOnly = true)
+    @AerospikeKey(storeAsBin = false)
     private long key;
     private String value;
 }
@@ -2025,7 +2025,7 @@ The key structure is used to specify the key to a record. Keys are optional in s
 
 The key structure contains:
 - **field**: The name of the field which to which this key is mapped. If this is provided, the getter and setter cannot be provided.
-- **storeInPkOnly**: Do not store the primary key column in the database, but rather use the `sendKey` facility related to Aerospike to save the key in the database. When the record is read, the value will be pulled back and place in the key field.
+- **storeAsBin**: Store the primary key as a bin in the database, alternatively it is recommended to use the `sendKey` facility related to Aerospike to save the key in the record's metadata (and set this flag to false). When the record is read, the value will be pulled back and place in the key field.
 - **getter**: The getter method used to populate the key. This must be used in conjunction with a setter method, and excludes the use of the field attribute.
 - **setter**: The setter method used to map data back to the Java key. This is used in conjunction with the getter method and precludes the use of the field attribute. Note that the return type of the getter must match the type of the first parameter of the setter, and the setter can have either 1 or 2 parameters, with the second (optional) parameter being either of type [com.aerospike.client.Key](https://www.aerospike.com/apidocs/java/com/aerospike/client/Key.html) or Object.
 

--- a/README.md
+++ b/README.md
@@ -729,7 +729,7 @@ Here are how standard Java types are mapped to Aerospike types:
 | Map<?,?> | Map |
 | Object Reference (@AerospikeRecord) | List or Map |
 
-These types are built into the converter. However, if you wish to change them, you can use a Custom Object Converter](#custom-object-converters). For example, if you want Dates stored in the database as a string, you could do:
+These types are built into the converter. However, if you wish to change them, you can use a [Custom Object Converter](#custom-object-converters). For example, if you want Dates stored in the database as a string, you could do:
 
 ```java
 public static class DateConverter {
@@ -2025,7 +2025,7 @@ The key structure is used to specify the key to a record. Keys are optional in s
 
 The key structure contains:
 - **field**: The name of the field which to which this key is mapped. If this is provided, the getter and setter cannot be provided.
-- **storeAsBin**: Store the primary key as a bin in the database, alternatively it is recommended to use the `sendKey` facility related to Aerospike to save the key in the record's metadata (and set this flag to false). When the record is read, the value will be pulled back and place in the key field.
+- **storeAsBin**: Store the primary key as a bin in the database, alternatively it is recommended to use the `sendKey` facility related to Aerospike to save the key in the record's metadata (and set this flag to false). When the record is read, the value will be pulled back and placed in the key field.
 - **getter**: The getter method used to populate the key. This must be used in conjunction with a setter method, and excludes the use of the field attribute.
 - **setter**: The setter method used to map data back to the Java key. This is used in conjunction with the getter method and precludes the use of the field attribute. Note that the return type of the getter must match the type of the first parameter of the setter, and the setter can have either 1 or 2 parameters, with the second (optional) parameter being either of type [com.aerospike.client.Key](https://www.aerospike.com/apidocs/java/com/aerospike/client/Key.html) or Object.
 

--- a/src/main/java/com/aerospike/mapper/annotations/AerospikeKey.java
+++ b/src/main/java/com/aerospike/mapper/annotations/AerospikeKey.java
@@ -12,6 +12,9 @@ public @interface AerospikeKey {
      * The setter attribute is used only on Methods where the method is used to set the key on lazy object instantiation
      */
     boolean setter() default false;
-    
+
+    /**
+     * Store the key as an Aerospike Bin, alternatively you can use @AerospikeRecord.sendKey to store the key in the record's metadata
+     */
     boolean storeAsBin() default true;
 }

--- a/src/main/java/com/aerospike/mapper/annotations/AerospikeKey.java
+++ b/src/main/java/com/aerospike/mapper/annotations/AerospikeKey.java
@@ -12,4 +12,6 @@ public @interface AerospikeKey {
      * The setter attribute is used only on Methods where the method is used to set the key on lazy object instantiation
      */
     boolean setter() default false;
+    
+    boolean storeInPkOnly() default false;
 }

--- a/src/main/java/com/aerospike/mapper/annotations/AerospikeKey.java
+++ b/src/main/java/com/aerospike/mapper/annotations/AerospikeKey.java
@@ -13,5 +13,5 @@ public @interface AerospikeKey {
      */
     boolean setter() default false;
     
-    boolean storeInPkOnly() default false;
+    boolean storeAsBin() default true;
 }

--- a/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
@@ -221,7 +221,7 @@ public class AeroMapper implements IAeroMapper {
             try {
                 ThreadLocalKeySaver.save(key);
                 LoadedObjectResolver.begin();
-                return mappingConverter.convertToObject(clazz, record, entry, resolveDependencies);
+                return mappingConverter.convertToObject(clazz, key, record, entry, resolveDependencies);
             } catch (ReflectiveOperationException e) {
                 throw new AerospikeException(e);
             } finally {
@@ -252,7 +252,7 @@ public class AeroMapper implements IAeroMapper {
             } else {
                 try {
                     ThreadLocalKeySaver.save(keys[i]);
-                    T result = mappingConverter.convertToObject(clazz, records[i], entry, false);
+                    T result = mappingConverter.convertToObject(clazz, keys[i], records[i], entry, false);
                     results[i] = result;
                 } catch (ReflectiveOperationException e) {
                     throw new AerospikeException(e);
@@ -372,7 +372,7 @@ public class AeroMapper implements IAeroMapper {
         AtomicBoolean userTerminated = new AtomicBoolean(false);
         try {
             mClient.scanAll(policy, namespace, setName, (key, record) -> {
-                T object = this.getMappingConverter().convertToObject(clazz, record);
+                T object = this.getMappingConverter().convertToObject(clazz, key, record);
                 if (!processor.process(object)) {
                     userTerminated.set(true);
                     throw new AerospikeException.ScanTerminated();
@@ -420,7 +420,7 @@ public class AeroMapper implements IAeroMapper {
         RecordSet recordSet = mClient.query(policy, statement);
         try {
             while (recordSet.next()) {
-                T object = this.getMappingConverter().convertToObject(clazz, recordSet.getRecord());
+                T object = this.getMappingConverter().convertToObject(clazz, recordSet.getKey(), recordSet.getRecord());
                 if (!processor.process(object)) {
                     break;
                 }

--- a/src/main/java/com/aerospike/mapper/tools/ClassCacheEntry.java
+++ b/src/main/java/com/aerospike/mapper/tools/ClassCacheEntry.java
@@ -632,7 +632,7 @@ public class ClassCacheEntry<T> {
             keyProperty.validate(clazz.getName(), config, true);
 
             if (key != null) {
-                throw new AerospikeException(String.format("Class %s cannot have a more than one key", clazz.getName()));
+                throw new AerospikeException(String.format("Class %s cannot have more than one key", clazz.getName()));
             }
 
             AnnotatedType annotatedType = new AnnotatedType(config, keyProperty.getGetter());
@@ -674,11 +674,11 @@ public class ClassCacheEntry<T> {
                 }
 
                 if (key != null) {
-                    throw new AerospikeException(String.format("Class %s cannot have a more than one key",
+                    throw new AerospikeException(String.format("Class %s cannot have more than one key",
                             clazz.getName()));
                 }
                 AerospikeKey keyAnnotation = thisField.getAnnotation(AerospikeKey.class);
-                boolean storeAsBin = (keyAnnotation == null) || (keyAnnotation != null && keyAnnotation.storeAsBin());
+                boolean storeAsBin = keyAnnotation == null || keyAnnotation.storeAsBin();
 
                 if (keyConfig != null && keyConfig.getStoreAsBin() != null) {
                     storeAsBin = keyConfig.getStoreAsBin();

--- a/src/main/java/com/aerospike/mapper/tools/ReactiveAeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/ReactiveAeroMapper.java
@@ -252,7 +252,7 @@ public class ReactiveAeroMapper implements IReactiveAeroMapper {
         if (writePolicy == null) {
             writePolicy = entry.getWritePolicy();
             if (entry.getDurableDelete() != null) {
-                // Clone the write policy so we're not changing the original one
+                // Clone the write policy, so we're not changing the original one
                 writePolicy = new WritePolicy(writePolicy);
                 writePolicy.durableDelete = entry.getDurableDelete();
             }

--- a/src/main/java/com/aerospike/mapper/tools/ReactiveAeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/ReactiveAeroMapper.java
@@ -201,7 +201,7 @@ public class ReactiveAeroMapper implements IReactiveAeroMapper {
                 .map(keyRecord -> {
                     try {
                         ThreadLocalKeySaver.save(key);
-                        return mappingConverter.convertToObject(clazz, keyRecord.record, entry, resolveDependencies);
+                        return mappingConverter.convertToObject(clazz, key, keyRecord.record, entry, resolveDependencies);
                     } catch (ReflectiveOperationException e) {
                         throw new AerospikeException(e);
                     } finally {
@@ -230,7 +230,7 @@ public class ReactiveAeroMapper implements IReactiveAeroMapper {
                 .map(keyRecord -> {
                     try {
                         ThreadLocalKeySaver.save(keyRecord.key);
-                        return mappingConverter.convertToObject(clazz, keyRecord.record, entry, true);
+                        return mappingConverter.convertToObject(clazz, keyRecord.key, keyRecord.record, entry, true);
                     } catch (ReflectiveOperationException e) {
                         throw new AerospikeException(e);
                     } finally {
@@ -324,7 +324,7 @@ public class ReactiveAeroMapper implements IReactiveAeroMapper {
         String setName = entry.getSetName();
 
         return reactorClient.scanAll(policy, namespace, setName)
-                .map(keyRecord -> getMappingConverter().convertToObject(clazz, keyRecord.record));
+                .map(keyRecord -> getMappingConverter().convertToObject(clazz, keyRecord.key, keyRecord.record));
     }
 
     @Override
@@ -344,7 +344,7 @@ public class ReactiveAeroMapper implements IReactiveAeroMapper {
         statement.setSetName(entry.getSetName());
 
         return reactorClient.query(policy, statement)
-                .map(keyRecord -> getMappingConverter().convertToObject(clazz, keyRecord.record));
+                .map(keyRecord -> getMappingConverter().convertToObject(clazz, keyRecord.key, keyRecord.record));
     }
 
     @Override

--- a/src/main/java/com/aerospike/mapper/tools/configuration/ClassConfig.java
+++ b/src/main/java/com/aerospike/mapper/tools/configuration/ClassConfig.java
@@ -232,8 +232,13 @@ public class ClassConfig {
         }
         
         public Builder withKeyFieldAndStoreAsBin(String fieldName, boolean storeAsBin) {
+            if (this.classConfig.getKey() == null) {
+                this.classConfig.setKey(new KeyConfig());
+            }
+            this.validateFieldExists(fieldName);
+            this.classConfig.getKey().setField(fieldName);
             this.classConfig.getKey().setStoreAsBin(storeAsBin);
-            return withKeyField(fieldName);
+            return this;
         }
         
         public Builder withKeyGetterAndSetterOf(String getterName, String setterName) {

--- a/src/main/java/com/aerospike/mapper/tools/configuration/ClassConfig.java
+++ b/src/main/java/com/aerospike/mapper/tools/configuration/ClassConfig.java
@@ -232,13 +232,8 @@ public class ClassConfig {
         }
         
         public Builder withKeyFieldAndStoreAsBin(String fieldName, boolean storeAsBin) {
-            if (this.classConfig.getKey() == null) {
-                this.classConfig.setKey(new KeyConfig());
-            }
-            this.validateFieldExists(fieldName);
-            this.classConfig.getKey().setField(fieldName);
             this.classConfig.getKey().setStoreAsBin(storeAsBin);
-            return this;
+            return withKeyField(fieldName);
         }
         
         public Builder withKeyGetterAndSetterOf(String getterName, String setterName) {

--- a/src/main/java/com/aerospike/mapper/tools/configuration/ClassConfig.java
+++ b/src/main/java/com/aerospike/mapper/tools/configuration/ClassConfig.java
@@ -231,13 +231,13 @@ public class ClassConfig {
             return this;
         }
         
-        public Builder withKeyFieldAndStorePkOnly(String fieldName, boolean storePkOnly) {
+        public Builder withKeyFieldAndStoreAsBin(String fieldName, boolean storeAsBin) {
             if (this.classConfig.getKey() == null) {
                 this.classConfig.setKey(new KeyConfig());
             }
             this.validateFieldExists(fieldName);
             this.classConfig.getKey().setField(fieldName);
-            this.classConfig.getKey().setStoreInPkOnly(storePkOnly);
+            this.classConfig.getKey().setStoreAsBin(storeAsBin);
             return this;
         }
         

--- a/src/main/java/com/aerospike/mapper/tools/configuration/ClassConfig.java
+++ b/src/main/java/com/aerospike/mapper/tools/configuration/ClassConfig.java
@@ -231,6 +231,16 @@ public class ClassConfig {
             return this;
         }
         
+        public Builder withKeyFieldAndStorePkOnly(String fieldName, boolean storePkOnly) {
+            if (this.classConfig.getKey() == null) {
+                this.classConfig.setKey(new KeyConfig());
+            }
+            this.validateFieldExists(fieldName);
+            this.classConfig.getKey().setField(fieldName);
+            this.classConfig.getKey().setStoreInPkOnly(storePkOnly);
+            return this;
+        }
+        
         public Builder withKeyGetterAndSetterOf(String getterName, String setterName) {
             if (this.classConfig.getKey() == null) {
                 this.classConfig.setKey(new KeyConfig());

--- a/src/main/java/com/aerospike/mapper/tools/configuration/KeyConfig.java
+++ b/src/main/java/com/aerospike/mapper/tools/configuration/KeyConfig.java
@@ -6,6 +6,7 @@ public class KeyConfig {
     private String field;
     private String getter;
     private String setter;
+    private Boolean storeInPkOnly;
 
     public String getField() {
         return field;
@@ -18,7 +19,14 @@ public class KeyConfig {
     public String getSetter() {
         return setter;
     }
+    
+    public Boolean getStoreInPkOnly() {
+        return storeInPkOnly;
+    }
 
+    public void setStoreInPkOnly(boolean value) {
+        this.storeInPkOnly = value;
+    }
     
     public void setField(String field) {
         this.field = field;

--- a/src/main/java/com/aerospike/mapper/tools/configuration/KeyConfig.java
+++ b/src/main/java/com/aerospike/mapper/tools/configuration/KeyConfig.java
@@ -6,7 +6,7 @@ public class KeyConfig {
     private String field;
     private String getter;
     private String setter;
-    private Boolean storeInPkOnly;
+    private Boolean storeAsBin;
 
     public String getField() {
         return field;
@@ -20,12 +20,12 @@ public class KeyConfig {
         return setter;
     }
     
-    public Boolean getStoreInPkOnly() {
-        return storeInPkOnly;
+    public Boolean getStoreAsBin() {
+        return storeAsBin;
     }
 
-    public void setStoreInPkOnly(boolean value) {
-        this.storeInPkOnly = value;
+    public void setStoreAsBin(boolean value) {
+        this.storeAsBin = value;
     }
     
     public void setField(String field) {

--- a/src/main/java/com/aerospike/mapper/tools/converters/MappingConverter.java
+++ b/src/main/java/com/aerospike/mapper/tools/converters/MappingConverter.java
@@ -206,7 +206,7 @@ public class MappingConverter {
     public void resolveDependencies(ClassCacheEntry<?> parentEntity) {
         List<DeferredObjectLoader.DeferredObjectSetter> deferredObjects = DeferredObjectLoader.getAndClear();
 
-        if (deferredObjects.size() == 0) {
+        if (deferredObjects.isEmpty()) {
             return;
         }
 

--- a/src/main/java/com/aerospike/mapper/tools/converters/MappingConverter.java
+++ b/src/main/java/com/aerospike/mapper/tools/converters/MappingConverter.java
@@ -78,9 +78,9 @@ public class MappingConverter {
      * @return A virtual list.
      * @throws AerospikeException an AerospikeException will be thrown in case of an encountering a ReflectiveOperationException.
      */
-    public <T> T convertToObject(Class<T> clazz, Record record) {
+    public <T> T convertToObject(Class<T> clazz, Key key, Record record) {
         try {
-            return convertToObject(clazz, record, null);
+            return convertToObject(clazz, key, record, null);
         } catch (ReflectiveOperationException e) {
             throw new AerospikeException(e);
         }
@@ -96,18 +96,18 @@ public class MappingConverter {
      * @return A virtual list.
      * @throws AerospikeException an AerospikeException will be thrown in case of an encountering a ReflectiveOperationException.
      */
-    public <T> T convertToObject(Class<T> clazz, Record record, ClassCacheEntry<T> entry) throws ReflectiveOperationException {
-        return this.convertToObject(clazz, record, entry, true);
+    public <T> T convertToObject(Class<T> clazz, Key key, Record record, ClassCacheEntry<T> entry) throws ReflectiveOperationException {
+        return this.convertToObject(clazz, key, record, entry, true);
     }
 
     /**
      * This method should not be used, it is public only to allow mappers to see it.
      */
-    public <T> T convertToObject(Class<T> clazz, Record record, ClassCacheEntry<T> entry, boolean resolveDependencies) throws ReflectiveOperationException {
+    public <T> T convertToObject(Class<T> clazz, Key key, Record record, ClassCacheEntry<T> entry, boolean resolveDependencies) throws ReflectiveOperationException {
         if (entry == null) {
             entry = ClassCache.getInstance().loadClass(clazz, mapper);
         }
-        T result = entry.constructAndHydrate(record);
+        T result = entry.constructAndHydrate(key, record);
         if (resolveDependencies) {
             resolveDependencies(entry);
         }
@@ -252,7 +252,7 @@ public class MappingConverter {
                     DeferredObjectLoader.DeferredObjectSetter thisObjectSetter = deferredObjects.get(i);
                     try {
                         ThreadLocalKeySaver.save(keys[i]);
-                        Object result = records[i] == null ? null : convertToObject((Class) thisObjectSetter.getObject().getType(), records[i], classCacheEntryList.get(i), false);
+                        Object result = records[i] == null ? null : convertToObject((Class) thisObjectSetter.getObject().getType(), keys[i], records[i], classCacheEntryList.get(i), false);
                         thisObjectSetter.getSetter().setValue(result);
                     } catch (ReflectiveOperationException e) {
                         throw new AerospikeException(e);

--- a/src/test/java/com/aerospike/mapper/AeroMapperBaseTest.java
+++ b/src/test/java/com/aerospike/mapper/AeroMapperBaseTest.java
@@ -25,7 +25,7 @@ public abstract class AeroMapperBaseTest {
         ClientPolicy policy = new ClientPolicy();
         // Set event loops to use in asynchronous commands.
         policy.eventLoops = new NioEventLoops(1);
-        client = new AerospikeClient(policy, "localhost", 3100);
+        client = new AerospikeClient(policy, "localhost", 3000);
     }
 
     @AfterAll

--- a/src/test/java/com/aerospike/mapper/AeroMapperBaseTest.java
+++ b/src/test/java/com/aerospike/mapper/AeroMapperBaseTest.java
@@ -25,7 +25,7 @@ public abstract class AeroMapperBaseTest {
         ClientPolicy policy = new ClientPolicy();
         // Set event loops to use in asynchronous commands.
         policy.eventLoops = new NioEventLoops(1);
-        client = new AerospikeClient(policy, "localhost", 3000);
+        client = new AerospikeClient(policy, "localhost", 3100);
     }
 
     @AfterAll

--- a/src/test/java/com/aerospike/mapper/UsePKColumnInsteadOfBinForKeyTest.java
+++ b/src/test/java/com/aerospike/mapper/UsePKColumnInsteadOfBinForKeyTest.java
@@ -1,0 +1,90 @@
+package com.aerospike.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.aerospike.client.Record;
+import com.aerospike.mapper.annotations.AerospikeKey;
+import com.aerospike.mapper.annotations.AerospikeRecord;
+import com.aerospike.mapper.tools.AeroMapper;
+import com.aerospike.mapper.tools.configuration.ClassConfig;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+public class UsePKColumnInsteadOfBinForKeyTest extends AeroMapperBaseTest {
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @AerospikeRecord(namespace = "test", set = "testSet", sendKey = true)
+    public static class A {
+        @AerospikeKey(storeInPkOnly = true)
+        private long key1;
+        private String value;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class B {
+        private String keyStr;
+        private String value;
+    }
+
+    @Test
+    public void runTest() {
+        AeroMapper mapper = new AeroMapper.Builder(client).build();
+        A a = new A(1, "test");
+        mapper.save(a);
+        
+        A readA = mapper.read(A.class,1);
+        assertTrue(readA.key1 == 1);
+        
+        Record rawObject = client.get(null, mapper.getRecordKey(a));
+        assertFalse(rawObject.bins.containsKey("key1"));
+    }
+    
+    @Test
+    public void runTestViaYaml() throws Exception {
+        String yaml = "---\n" +
+                "classes:\n" +
+                " - class: com.aerospike.mapper.UsePKColumnInsteadOfBinForKeyTest$B\n" +
+                "   namespace: test\n" + 
+                "   set: testSet\n" + 
+                "   sendKey: true\n" + 
+                "   key:\n" +
+                "     field: keyStr\n" + 
+                "     storeInPkOnly: true\n";
+        AeroMapper mapper = new AeroMapper.Builder(client).withConfiguration(yaml).build();
+        B b = new B("key1", "test1");
+        mapper.save(b);
+        
+        B readB = mapper.read(B.class,"key1");
+        assertTrue("key1".equals(readB.keyStr));
+        
+        Record rawObject = client.get(null, mapper.getRecordKey(b));
+        assertFalse(rawObject.bins.containsKey("keyStr"));
+    }
+
+    @Test
+    public void runTestViaConfig() throws Exception {
+        ClassConfig classBConfig = new ClassConfig.Builder(B.class)
+                .withNamespace("test")
+                .withSet("testSet")
+                .withSendKey(true)
+                .withKeyFieldAndStorePkOnly("keyStr", true).build();
+        AeroMapper mapper = new AeroMapper.Builder(client).withClassConfigurations(classBConfig).build();
+        B b = new B("key2", "test2");
+        mapper.save(b);
+        
+        B readB = mapper.read(B.class,"key2");
+        assertTrue("key2".equals(readB.keyStr));
+        
+        Record rawObject = client.get(null, mapper.getRecordKey(b));
+        assertFalse(rawObject.bins.containsKey("keyStr"));
+    }
+}

--- a/src/test/java/com/aerospike/mapper/UsePKColumnInsteadOfBinForKeyTest.java
+++ b/src/test/java/com/aerospike/mapper/UsePKColumnInsteadOfBinForKeyTest.java
@@ -1,22 +1,20 @@
 package com.aerospike.mapper;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
-
 import com.aerospike.client.Record;
 import com.aerospike.mapper.annotations.AerospikeKey;
 import com.aerospike.mapper.annotations.AerospikeRecord;
 import com.aerospike.mapper.tools.AeroMapper;
 import com.aerospike.mapper.tools.configuration.ClassConfig;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class UsePKColumnInsteadOfBinForKeyTest extends AeroMapperBaseTest {
+
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
@@ -40,38 +38,38 @@ public class UsePKColumnInsteadOfBinForKeyTest extends AeroMapperBaseTest {
         AeroMapper mapper = new AeroMapper.Builder(client).build();
         A a = new A(1, "test");
         mapper.save(a);
-        
-        A readA = mapper.read(A.class,1);
-        assertTrue(readA.key1 == 1);
-        
+
+        A readA = mapper.read(A.class, 1);
+        assertEquals(1, readA.key1);
+
         Record rawObject = client.get(null, mapper.getRecordKey(a));
         assertFalse(rawObject.bins.containsKey("key1"));
     }
-    
+
     @Test
     public void runTestViaYaml() throws Exception {
         String yaml = "---\n" +
                 "classes:\n" +
                 " - class: com.aerospike.mapper.UsePKColumnInsteadOfBinForKeyTest$B\n" +
-                "   namespace: test\n" + 
-                "   set: testSet\n" + 
-                "   sendKey: true\n" + 
+                "   namespace: test\n" +
+                "   set: testSet\n" +
+                "   sendKey: true\n" +
                 "   key:\n" +
-                "     field: keyStr\n" + 
+                "     field: keyStr\n" +
                 "     storeInPkOnly: true\n";
         AeroMapper mapper = new AeroMapper.Builder(client).withConfiguration(yaml).build();
         B b = new B("key1", "test1");
         mapper.save(b);
-        
-        B readB = mapper.read(B.class,"key1");
-        assertTrue("key1".equals(readB.keyStr));
-        
+
+        B readB = mapper.read(B.class, "key1");
+        assertEquals("key1", readB.keyStr);
+
         Record rawObject = client.get(null, mapper.getRecordKey(b));
         assertFalse(rawObject.bins.containsKey("keyStr"));
     }
 
     @Test
-    public void runTestViaConfig() throws Exception {
+    public void runTestViaConfig() {
         ClassConfig classBConfig = new ClassConfig.Builder(B.class)
                 .withNamespace("test")
                 .withSet("testSet")
@@ -80,10 +78,10 @@ public class UsePKColumnInsteadOfBinForKeyTest extends AeroMapperBaseTest {
         AeroMapper mapper = new AeroMapper.Builder(client).withClassConfigurations(classBConfig).build();
         B b = new B("key2", "test2");
         mapper.save(b);
-        
-        B readB = mapper.read(B.class,"key2");
-        assertTrue("key2".equals(readB.keyStr));
-        
+
+        B readB = mapper.read(B.class, "key2");
+        assertEquals("key2", readB.keyStr);
+
         Record rawObject = client.get(null, mapper.getRecordKey(b));
         assertFalse(rawObject.bins.containsKey("keyStr"));
     }

--- a/src/test/java/com/aerospike/mapper/reactive/ReactiveUsePKColumnInsteadOfBinForKeyTest.java
+++ b/src/test/java/com/aerospike/mapper/reactive/ReactiveUsePKColumnInsteadOfBinForKeyTest.java
@@ -1,0 +1,96 @@
+package com.aerospike.mapper.reactive;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.aerospike.client.Record;
+import com.aerospike.client.query.KeyRecord;
+import com.aerospike.mapper.UsePKColumnInsteadOfBinForKeyTest;
+import com.aerospike.mapper.UsePKColumnInsteadOfBinForKeyTest.B;
+import com.aerospike.mapper.annotations.AerospikeKey;
+import com.aerospike.mapper.annotations.AerospikeRecord;
+import com.aerospike.mapper.tools.AeroMapper;
+import com.aerospike.mapper.tools.ReactiveAeroMapper;
+import com.aerospike.mapper.tools.configuration.ClassConfig;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import reactor.core.scheduler.Schedulers;
+
+
+public class ReactiveUsePKColumnInsteadOfBinForKeyTest extends ReactiveAeroMapperBaseTest {
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @AerospikeRecord(namespace = "test", set = "testSet", sendKey = true)
+    public static class A {
+        @AerospikeKey(storeInPkOnly = true)
+        private long key1;
+        private String value;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class B {
+        private String keyStr;
+        private String value;
+    }
+
+    @Test
+    public void runTest() {
+        ReactiveAeroMapper reactiveMapper = new ReactiveAeroMapper.Builder(reactorClient).build();
+        A a = new A(1, "test");
+        reactiveMapper.save(a).subscribeOn(Schedulers.parallel()).block();
+        
+        A readA = reactiveMapper.read(A.class, 1).subscribeOn(Schedulers.parallel()).block();
+        assertTrue(readA.key1 == 1);
+        
+        KeyRecord rawObject = reactorClient.get(null, reactiveMapper.getRecordKey(a).block()).block();
+        assertFalse(rawObject.record.bins.containsKey("key1"));
+    }
+    
+    @Test
+    public void runTestViaYaml() throws Exception {
+        String yaml = "---\n" +
+                "classes:\n" +
+                " - class: com.aerospike.mapper.reactive.ReactiveUsePKColumnInsteadOfBinForKeyTest$B\n" +
+                "   namespace: test\n" + 
+                "   set: testSet\n" + 
+                "   sendKey: true\n" + 
+                "   key:\n" +
+                "     field: keyStr\n" + 
+                "     storeInPkOnly: true\n";
+        ReactiveAeroMapper reactiveMapper = new ReactiveAeroMapper.Builder(reactorClient).withConfiguration(yaml).build();
+        B b = new B("key1", "test1");
+        reactiveMapper.save(b).subscribeOn(Schedulers.parallel()).block();
+        
+        B readB = reactiveMapper.read(B.class, "key1").subscribeOn(Schedulers.parallel()).block();
+        assertTrue("key1".equals(readB.keyStr));
+        
+        KeyRecord rawObject = reactorClient.get(null, reactiveMapper.getRecordKey(b).block()).block();
+        assertFalse(rawObject.record.bins.containsKey("keyStr"));
+    }
+
+    @Test
+    public void runTestViaConfig() throws Exception {
+        ClassConfig classBConfig = new ClassConfig.Builder(B.class)
+                .withNamespace("test")
+                .withSet("testSet")
+                .withSendKey(true)
+                .withKeyFieldAndStorePkOnly("keyStr", true).build();
+        ReactiveAeroMapper reactiveMapper = new ReactiveAeroMapper.Builder(reactorClient).withClassConfigurations(classBConfig).build();
+        B b = new B("key2", "test2");
+        reactiveMapper.save(b).subscribeOn(Schedulers.parallel()).block();
+        
+        B readB = reactiveMapper.read(B.class, "key2").subscribeOn(Schedulers.parallel()).block();
+        assertTrue("key2".equals(readB.keyStr));
+        
+        KeyRecord rawObject = reactorClient.get(null, reactiveMapper.getRecordKey(b).block()).block();
+        assertFalse(rawObject.record.bins.containsKey("keyStr"));
+    }
+
+}

--- a/src/test/java/com/aerospike/mapper/reactive/ReactiveUsePKColumnInsteadOfBinForKeyTest.java
+++ b/src/test/java/com/aerospike/mapper/reactive/ReactiveUsePKColumnInsteadOfBinForKeyTest.java
@@ -1,27 +1,20 @@
 package com.aerospike.mapper.reactive;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
-
-import com.aerospike.client.Record;
 import com.aerospike.client.query.KeyRecord;
-import com.aerospike.mapper.UsePKColumnInsteadOfBinForKeyTest;
-import com.aerospike.mapper.UsePKColumnInsteadOfBinForKeyTest.B;
 import com.aerospike.mapper.annotations.AerospikeKey;
 import com.aerospike.mapper.annotations.AerospikeRecord;
-import com.aerospike.mapper.tools.AeroMapper;
 import com.aerospike.mapper.tools.ReactiveAeroMapper;
 import com.aerospike.mapper.tools.configuration.ClassConfig;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
 import reactor.core.scheduler.Schedulers;
 
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ReactiveUsePKColumnInsteadOfBinForKeyTest extends ReactiveAeroMapperBaseTest {
+
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
@@ -45,38 +38,42 @@ public class ReactiveUsePKColumnInsteadOfBinForKeyTest extends ReactiveAeroMappe
         ReactiveAeroMapper reactiveMapper = new ReactiveAeroMapper.Builder(reactorClient).build();
         A a = new A(1, "test");
         reactiveMapper.save(a).subscribeOn(Schedulers.parallel()).block();
-        
+
         A readA = reactiveMapper.read(A.class, 1).subscribeOn(Schedulers.parallel()).block();
-        assertTrue(readA.key1 == 1);
-        
+        assertNotNull(readA);
+        assertEquals(1, readA.key1);
+
         KeyRecord rawObject = reactorClient.get(null, reactiveMapper.getRecordKey(a).block()).block();
+        assertNotNull(rawObject);
         assertFalse(rawObject.record.bins.containsKey("key1"));
     }
-    
+
     @Test
     public void runTestViaYaml() throws Exception {
         String yaml = "---\n" +
                 "classes:\n" +
                 " - class: com.aerospike.mapper.reactive.ReactiveUsePKColumnInsteadOfBinForKeyTest$B\n" +
-                "   namespace: test\n" + 
-                "   set: testSet\n" + 
-                "   sendKey: true\n" + 
+                "   namespace: test\n" +
+                "   set: testSet\n" +
+                "   sendKey: true\n" +
                 "   key:\n" +
-                "     field: keyStr\n" + 
+                "     field: keyStr\n" +
                 "     storeInPkOnly: true\n";
         ReactiveAeroMapper reactiveMapper = new ReactiveAeroMapper.Builder(reactorClient).withConfiguration(yaml).build();
         B b = new B("key1", "test1");
         reactiveMapper.save(b).subscribeOn(Schedulers.parallel()).block();
-        
+
         B readB = reactiveMapper.read(B.class, "key1").subscribeOn(Schedulers.parallel()).block();
-        assertTrue("key1".equals(readB.keyStr));
-        
+        assertNotNull(readB);
+        assertEquals("key1", readB.keyStr);
+
         KeyRecord rawObject = reactorClient.get(null, reactiveMapper.getRecordKey(b).block()).block();
+        assertNotNull(rawObject);
         assertFalse(rawObject.record.bins.containsKey("keyStr"));
     }
 
     @Test
-    public void runTestViaConfig() throws Exception {
+    public void runTestViaConfig() {
         ClassConfig classBConfig = new ClassConfig.Builder(B.class)
                 .withNamespace("test")
                 .withSet("testSet")
@@ -85,12 +82,13 @@ public class ReactiveUsePKColumnInsteadOfBinForKeyTest extends ReactiveAeroMappe
         ReactiveAeroMapper reactiveMapper = new ReactiveAeroMapper.Builder(reactorClient).withClassConfigurations(classBConfig).build();
         B b = new B("key2", "test2");
         reactiveMapper.save(b).subscribeOn(Schedulers.parallel()).block();
-        
+
         B readB = reactiveMapper.read(B.class, "key2").subscribeOn(Schedulers.parallel()).block();
-        assertTrue("key2".equals(readB.keyStr));
-        
+        assertNotNull(readB);
+        assertEquals("key2", readB.keyStr);
+
         KeyRecord rawObject = reactorClient.get(null, reactiveMapper.getRecordKey(b).block()).block();
+        assertNotNull(rawObject);
         assertFalse(rawObject.record.bins.containsKey("keyStr"));
     }
-
 }

--- a/src/test/java/com/aerospike/mapper/reactive/ReactiveUsePKColumnInsteadOfBinForKeyTest.java
+++ b/src/test/java/com/aerospike/mapper/reactive/ReactiveUsePKColumnInsteadOfBinForKeyTest.java
@@ -20,7 +20,7 @@ public class ReactiveUsePKColumnInsteadOfBinForKeyTest extends ReactiveAeroMappe
     @NoArgsConstructor
     @AerospikeRecord(namespace = "test", set = "testSet", sendKey = true)
     public static class A {
-        @AerospikeKey(storeInPkOnly = true)
+        @AerospikeKey(storeAsBin = false)
         private long key1;
         private String value;
     }
@@ -58,7 +58,7 @@ public class ReactiveUsePKColumnInsteadOfBinForKeyTest extends ReactiveAeroMappe
                 "   sendKey: true\n" +
                 "   key:\n" +
                 "     field: keyStr\n" +
-                "     storeInPkOnly: true\n";
+                "     storeAsBin: false\n";
         ReactiveAeroMapper reactiveMapper = new ReactiveAeroMapper.Builder(reactorClient).withConfiguration(yaml).build();
         B b = new B("key1", "test1");
         reactiveMapper.save(b).subscribeOn(Schedulers.parallel()).block();
@@ -78,7 +78,7 @@ public class ReactiveUsePKColumnInsteadOfBinForKeyTest extends ReactiveAeroMappe
                 .withNamespace("test")
                 .withSet("testSet")
                 .withSendKey(true)
-                .withKeyFieldAndStorePkOnly("keyStr", true).build();
+                .withKeyFieldAndStoreAsBin("keyStr", false).build();
         ReactiveAeroMapper reactiveMapper = new ReactiveAeroMapper.Builder(reactorClient).withClassConfigurations(classBConfig).build();
         B b = new B("key2", "test2");
         reactiveMapper.save(b).subscribeOn(Schedulers.parallel()).block();


### PR DESCRIPTION
Added functionality to allow the record key to be stored in the database key field rather than requiring an explicit bin.