### PR TITLE
Memory leak: do not save objects if no references to cache

### DIFF
--- a/src/main/java/com/aerospike/mapper/tools/LoadedObjectResolver.java
+++ b/src/main/java/com/aerospike/mapper/tools/LoadedObjectResolver.java
@@ -30,7 +30,7 @@ public class LoadedObjectResolver {
     public static void setObjectForCurrentKey(Object object) {
         Key currentKey = ThreadLocalKeySaver.get();
         LoadedObjectMap map = threadLocalObjects.get();
-        if (currentKey != null) {
+        if (currentKey != null && map.referenceCount > 0) {
             map.objectMap.put(currentKey, object);
         }
     }


### PR DESCRIPTION
Hi

I found memory leak inside `ReactiveAeroMapper`. https://github.com/aerospike/java-object-mapper/blob/0e422d79a6eab78e3767091a27620311fb8982e2/src/main/java/com/aerospike/mapper/tools/ReactiveAeroMapper.java#L218

This code allows to save objects into map, but do not increase/decrease reference count, therefore objects permanently stored inside cache. Sync version of mapper has `begin()` and `end()` calls for reference counting and doesn't have this problem.

I suggest add verification inside `LoadedObjectResolver` or add `begin()` and `end()` calls into `ReactiveAeroMapper`

Thanks