### PR TITLE
Configure permissions in the snyk scan workflow

### DIFF
--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   snyk-security:
+    permissions:
+      security-events: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR addresses the `snyk requires an authenticated account. Please run snyk auth and try again.` error when running security scan.