### PR TITLE
FMWK-496 Resolve potential memory leak related to object references

### DIFF
--- a/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
@@ -1,13 +1,5 @@
 package com.aerospike.mapper.tools;
 
-import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
-
-import javax.validation.constraints.NotNull;
-
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.AerospikeException.ScanTerminated;
 import com.aerospike.client.Bin;
@@ -29,7 +21,13 @@ import com.aerospike.mapper.tools.ClassCache.PolicyType;
 import com.aerospike.mapper.tools.converters.MappingConverter;
 import com.aerospike.mapper.tools.utils.MapperUtils;
 import com.aerospike.mapper.tools.virtuallist.VirtualList;
-import reactor.core.publisher.Mono;
+
+import javax.validation.constraints.NotNull;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 public class AeroMapper implements IAeroMapper {
 
@@ -42,7 +40,7 @@ public class AeroMapper implements IAeroMapper {
     }
 
     /**
-     * Create a new Builder to instantiate the AeroMapper. 
+     * Create a new Builder to instantiate the AeroMapper.
      * @author tfaulkes
      *
      */
@@ -233,12 +231,10 @@ public class AeroMapper implements IAeroMapper {
         } else {
             try {
                 ThreadLocalKeySaver.save(key);
-                LoadedObjectResolver.begin();
                 return mappingConverter.convertToObject(clazz, key, record, entry, resolveDependencies);
             } catch (ReflectiveOperationException e) {
                 throw new AerospikeException(e);
             } finally {
-                LoadedObjectResolver.end();
                 ThreadLocalKeySaver.clear();
             }
         }

--- a/src/main/java/com/aerospike/mapper/tools/LoadedObjectResolver.java
+++ b/src/main/java/com/aerospike/mapper/tools/LoadedObjectResolver.java
@@ -1,18 +1,16 @@
 package com.aerospike.mapper.tools;
 
+import com.aerospike.client.Key;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import com.aerospike.client.Key;
-
 public class LoadedObjectResolver {
 
-    private static class LoadedObjectMap {
-        private int referenceCount = 0;
-        private final Map<Key, Object> objectMap = new HashMap<>();
-    }
-
     private static final ThreadLocal<LoadedObjectMap> threadLocalObjects = ThreadLocal.withInitial(LoadedObjectMap::new);
+
+    private LoadedObjectResolver() {
+    }
 
     public static void begin() {
         LoadedObjectMap map = threadLocalObjects.get();
@@ -23,7 +21,7 @@ public class LoadedObjectResolver {
         LoadedObjectMap map = threadLocalObjects.get();
         map.referenceCount--;
         if (map.referenceCount == 0) {
-            map.objectMap.clear();
+            threadLocalObjects.remove();
         }
     }
 
@@ -38,5 +36,10 @@ public class LoadedObjectResolver {
     public static Object get(Key key) {
         LoadedObjectMap map = threadLocalObjects.get();
         return map.objectMap.get(key);
+    }
+
+    private static class LoadedObjectMap {
+        private final Map<Key, Object> objectMap = new HashMap<>();
+        private int referenceCount = 0;
     }
 }

--- a/src/main/java/com/aerospike/mapper/tools/ReactiveAeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/ReactiveAeroMapper.java
@@ -210,12 +210,10 @@ public class ReactiveAeroMapper implements IReactiveAeroMapper {
                 .map(keyRecord -> {
                     try {
                         ThreadLocalKeySaver.save(key);
-                        LoadedObjectResolver.begin();
                         return mappingConverter.convertToObject(clazz, key, keyRecord.record, entry, resolveDependencies);
                     } catch (ReflectiveOperationException e) {
                         throw new AerospikeException(e);
                     } finally {
-                        LoadedObjectResolver.end();
                         ThreadLocalKeySaver.clear();
                     }
                 });

--- a/src/main/java/com/aerospike/mapper/tools/ThreadLocalKeySaver.java
+++ b/src/main/java/com/aerospike/mapper/tools/ThreadLocalKeySaver.java
@@ -1,17 +1,20 @@
 package com.aerospike.mapper.tools;
 
+import com.aerospike.client.Key;
+
 import java.util.ArrayDeque;
 import java.util.Deque;
 
-import com.aerospike.client.Key;
-
 /**
- * Save the keys. Note that this is effectively a stack of keys, as A can load B which can load C, and C needs B's key, not A's.
- *
- * @author timfaulkes
+ * Save the keys. Note that this is effectively a stack of keys, as A can load B which can load C, and C needs B's key,
+ * not A's.
  */
 public class ThreadLocalKeySaver {
+
     private static final ThreadLocal<Deque<Key>> threadLocalKeys = ThreadLocal.withInitial(ArrayDeque::new);
+
+    private ThreadLocalKeySaver() {
+    }
 
     public static void save(Key key) {
         threadLocalKeys.get().addLast(key);
@@ -19,6 +22,9 @@ public class ThreadLocalKeySaver {
 
     public static void clear() {
         threadLocalKeys.get().removeLast();
+        if (threadLocalKeys.get().isEmpty()) {
+            threadLocalKeys.remove();
+        }
     }
 
     public static Key get() {

--- a/src/main/java/com/aerospike/mapper/tools/ThreadLocalKeySaver.java
+++ b/src/main/java/com/aerospike/mapper/tools/ThreadLocalKeySaver.java
@@ -18,9 +18,11 @@ public class ThreadLocalKeySaver {
 
     public static void save(Key key) {
         threadLocalKeys.get().addLast(key);
+        LoadedObjectResolver.begin();
     }
 
     public static void clear() {
+        LoadedObjectResolver.end();
         threadLocalKeys.get().removeLast();
         if (threadLocalKeys.get().isEmpty()) {
             threadLocalKeys.remove();

--- a/src/test/java/com/aerospike/mapper/reactive/ReactiveRecursiveObjectTest.java
+++ b/src/test/java/com/aerospike/mapper/reactive/ReactiveRecursiveObjectTest.java
@@ -1,0 +1,62 @@
+package com.aerospike.mapper.reactive;
+
+import com.aerospike.mapper.RecursiveObjectTest;
+import com.aerospike.mapper.tools.ReactiveAeroMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ReactiveRecursiveObjectTest extends ReactiveAeroMapperBaseTest {
+
+    @Test
+    public void runTest() {
+        RecursiveObjectTest.A a1 = new RecursiveObjectTest.A("a", 10, 1);
+        a1.a = a1;
+
+        ReactiveAeroMapper reactiveMapper = new ReactiveAeroMapper.Builder(reactorClient).build();
+        reactiveMapper.save(a1).block();
+
+        RecursiveObjectTest.A a2 = reactiveMapper.read(RecursiveObjectTest.A.class, a1.id).block();
+        assertNotNull(a2);
+        assertEquals(a1.age, a2.age);
+        assertEquals(a1.name, a2.name);
+        assertEquals(a1.id, a2.id);
+    }
+
+    @Test
+    public void runMultipleObjectTest() {
+        RecursiveObjectTest.A a1 = new RecursiveObjectTest.A("a", 10, 1);
+        a1.a = a1;
+        RecursiveObjectTest.B b = new RecursiveObjectTest.B();
+        b.id = 10;
+        b.a = a1;
+
+        ReactiveAeroMapper reactiveMapper = new ReactiveAeroMapper.Builder(reactorClient).build();
+        reactiveMapper.save(a1).block();
+        reactiveMapper.save(b).block();
+
+        RecursiveObjectTest.B b2 = reactiveMapper.read(RecursiveObjectTest.B.class, b.id).block();
+        assertNotNull(b2);
+        assertEquals(b.id, b2.id);
+        assertEquals(b.a.age, b2.a.age);
+        assertEquals(b.a.name, b2.a.name);
+        assertEquals(b.a.id, b2.a.id);
+    }
+
+    @Test
+    public void runTest2() {
+        RecursiveObjectTest.A a1 = new RecursiveObjectTest.A("a", 10, 1);
+        a1.a = new RecursiveObjectTest.A("a2", 11, 11);
+
+        ReactiveAeroMapper reactiveMapper = new ReactiveAeroMapper.Builder(reactorClient).build();
+        reactiveMapper.save(a1, a1.a).blockLast();
+
+        RecursiveObjectTest.A a2 = reactiveMapper.read(RecursiveObjectTest.A.class, a1.id).block();
+        assertNotNull(a2);
+        assertEquals(a1.age, a2.age);
+        assertEquals(a1.name, a2.name);
+        assertEquals(a1.id, a2.id);
+        assertEquals(a1.a.id, a2.a.id);
+    }
+}


### PR DESCRIPTION
* Add `LoadedObjectResolver.begin()` and `LoadedObjectResolver.end()` calls in the reactive read method.
* Use `remove` to clear `ThreadLocal` values.