### PR TITLE
fix: synchronize result processor in scan callback

### DIFF
--- a/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
+++ b/src/main/java/com/aerospike/mapper/tools/AeroMapper.java
@@ -398,7 +398,9 @@ public class AeroMapper implements IAeroMapper {
     public <T> List<T> scan(ScanPolicy policy, @NotNull Class<T> clazz) {
         List<T> result = new ArrayList<>();
         Processor<T> resultProcessor = record -> {
-            result.add(record);
+            synchronized(result) {
+                result.add(record);
+            }
             return true;
         };
         scan(policy, clazz, resultProcessor);


### PR DESCRIPTION
When executing scan in parallel with scanPolicy.concurrentNodes = true, the results were inconsistent due to add method of ArrayList not being thread safe. Added synchronized keyword to prevent race condition.